### PR TITLE
fix: register ablation marker and avoid eager default in gap collector

### DIFF
--- a/apps/api/app/transcription.py
+++ b/apps/api/app/transcription.py
@@ -854,15 +854,14 @@ def collect_attack_validated_gap_segments(
     segments: list[tuple[float, float]] = []
 
     def _valid_gap_onsets(gap_start: float, gap_end: float) -> list[float]:
-        return [
-            time
-            for time in onset_times
-            if gap_start + 0.05 < time < gap_end - 0.05
-            and onset_profiles.get(round(time, 4), OnsetAttackProfile(
-                onset_time=time, broadband_onset_gain=0.0, high_band_spectral_flux=0.0,
-                broadband_spectral_flux=0.0, is_valid_attack=False,
-            )).is_valid_attack
-        ]
+        valid: list[float] = []
+        for time in onset_times:
+            if not (gap_start + 0.05 < time < gap_end - 0.05):
+                continue
+            profile = onset_profiles.get(round(time, 4))
+            if profile is not None and profile.is_valid_attack:
+                valid.append(time)
+        return valid
 
     # Inter-range gaps
     for index in range(len(active_ranges) - 1):

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,4 @@
 markers =
     manual_capture: tests that exercise manual audio capture fixtures
     slow: long-running regression and integration tests
+    ablation: ablation tests that disable individual collectors


### PR DESCRIPTION
- Register `ablation` marker in pytest.ini to suppress unknown-marker warnings in test_ablation_pure.py and test_ablation_attack_validated.py
- Replace eager OnsetAttackProfile default construction in _valid_gap_onsets with explicit None check to avoid unnecessary object creation per iteration