### PR TITLE
feat: formalize segment_peaks primary-rejection contract (#65)

### DIFF
--- a/apps/api/app/transcription.py
+++ b/apps/api/app/transcription.py
@@ -182,6 +182,8 @@ HARMONIC_WEIGHTS = [1.0, 0.55, 0.3, 0.15]
 HARMONIC_BAND_CENTS = 40.0
 SUPPRESSION_BAND_CENTS = 45.0
 MAX_POLYPHONY = 4
+PRIMARY_REJECTION_MAX_SCORE = 5.0
+PRIMARY_REJECTION_MAX_FUNDAMENTAL_RATIO = 0.5
 TERTIARY_MIN_SCORE_RATIO = 0.12
 TERTIARY_MIN_FUNDAMENTAL_RATIO = 0.85
 TERTIARY_MIN_SCORE = 20.0
@@ -3335,6 +3337,11 @@ def segment_peaks(
     )
     if recent_upper_alias_promotion_debug is not None:
         primary_promotion_debug = recent_upper_alias_promotion_debug
+    if (
+        primary.score < PRIMARY_REJECTION_MAX_SCORE
+        and primary.fundamental_ratio < PRIMARY_REJECTION_MAX_FUNDAMENTAL_RATIO
+    ):
+        return [], None, None
     selected = [primary.candidate]
     residual_ranked: list[NoteHypothesis] = []
     promoted_secondary_to_recent_upper_octave = False

--- a/apps/api/tests/test_segment_peaks.py
+++ b/apps/api/tests/test_segment_peaks.py
@@ -2,7 +2,13 @@ import numpy as np
 import pytest
 
 from app.tunings import get_default_tunings
-from app.transcription import NoteCandidate, NoteHypothesis, segment_peaks
+from app.transcription import (
+    NoteCandidate,
+    NoteHypothesis,
+    PRIMARY_REJECTION_MAX_SCORE,
+    PRIMARY_REJECTION_MAX_FUNDAMENTAL_RATIO,
+    segment_peaks,
+)
 from conftest import synthesize_note, synthesize_chord
 
 
@@ -321,3 +327,96 @@ def test_segment_peaks_suppresses_descending_restart_upper_carryover(monkeypatch
         and "descending-restart-upper-carryover" in item.get("reasons", [])
         for item in debug["secondaryDecisionTrail"]
     )
+
+
+def test_segment_peaks_rejects_weak_primary_with_low_score_and_fundamental_ratio(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Primary with both low score and low fundamental ratio is rejected."""
+    import app.transcription as transcription
+
+    tuning = get_default_tunings()[0]
+    e6 = NoteCandidate(key=0, note_name="E6", frequency=1318.5102276514797, pitch_class="E", octave=6)
+
+    def fake_rank_tuning_candidates(_frequencies, _spectrum, _tuning, debug=False):
+        return [
+            NoteHypothesis(e6, PRIMARY_REJECTION_MAX_SCORE - 1, 0.0, 0.0,
+                           PRIMARY_REJECTION_MAX_FUNDAMENTAL_RATIO - 0.1, 0.0, 0.0, 0.0, 0.0),
+        ]
+
+    monkeypatch.setattr(transcription, "rank_tuning_candidates", fake_rank_tuning_candidates)
+
+    candidates, debug, primary = segment_peaks(
+        synthesize_note(e6.frequency, duration=0.2),
+        44100,
+        0.0,
+        0.2,
+        tuning,
+        debug=True,
+    )
+
+    assert candidates == []
+    assert primary is None
+    assert debug is None
+
+
+def test_segment_peaks_keeps_low_score_primary_with_high_fundamental_ratio(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Low score alone does not trigger rejection when fundamental ratio is adequate."""
+    import app.transcription as transcription
+
+    tuning = get_default_tunings()[0]
+    c4 = NoteCandidate(key=9, note_name="C4", frequency=261.6255653005986, pitch_class="C", octave=4)
+
+    def fake_rank_tuning_candidates(_frequencies, _spectrum, _tuning, debug=False):
+        return [
+            NoteHypothesis(c4, PRIMARY_REJECTION_MAX_SCORE - 1, 0.0, 0.0,
+                           0.85, 0.0, 0.0, 0.0, 0.0),
+        ]
+
+    monkeypatch.setattr(transcription, "rank_tuning_candidates", fake_rank_tuning_candidates)
+
+    candidates, debug, primary = segment_peaks(
+        synthesize_note(c4.frequency, duration=0.2),
+        44100,
+        0.0,
+        0.2,
+        tuning,
+        debug=True,
+    )
+
+    assert primary is not None
+    assert primary.candidate.note_name == "C4"
+    assert len(candidates) >= 1
+
+
+def test_segment_peaks_keeps_high_score_primary_with_low_fundamental_ratio(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Low fundamental ratio alone does not trigger rejection when score is adequate."""
+    import app.transcription as transcription
+
+    tuning = get_default_tunings()[0]
+    d4 = NoteCandidate(key=8, note_name="D4", frequency=293.6647679174076, pitch_class="D", octave=4)
+
+    def fake_rank_tuning_candidates(_frequencies, _spectrum, _tuning, debug=False):
+        return [
+            NoteHypothesis(d4, 50.0, 0.0, 0.0,
+                           PRIMARY_REJECTION_MAX_FUNDAMENTAL_RATIO - 0.1, 0.0, 0.0, 0.0, 0.0),
+        ]
+
+    monkeypatch.setattr(transcription, "rank_tuning_candidates", fake_rank_tuning_candidates)
+
+    candidates, debug, primary = segment_peaks(
+        synthesize_note(d4.frequency, duration=0.2),
+        44100,
+        0.0,
+        0.2,
+        tuning,
+        debug=True,
+    )
+
+    assert primary is not None
+    assert primary.candidate.note_name == "D4"
+    assert len(candidates) >= 1


### PR DESCRIPTION
## Summary

- Add late rejection path in `segment_peaks` after primary selection/promotion
- Combined criterion: `score < 5.0 AND fundamental_ratio < 0.5`
- 3 mechanism tests added
- 287 passed, 0 regressions

## Changes

### Late rejection path (transcription.py)

After all primary promotion passes (stale recent, upper octave, recent upper alias), a new guard rejects the primary when **both** conditions are met:
- `primary.score < PRIMARY_REJECTION_MAX_SCORE` (5.0)
- `primary.fundamental_ratio < PRIMARY_REJECTION_MAX_FUNDAMENTAL_RATIO` (0.5)

Returns `([], None, None)` — the existing callsite `if not candidates or primary is None: continue` handles this safely.

### Why combined criterion

A single score threshold doesn't work: completed fixtures contain legitimate events with scores as low as 0.09 (e.g., `e6-to-c4-sequence-51-01` at 1.099s with FR=0.827). The combined criterion preserves these by requiring low FR as a co-condition — genuine notes with low scores still have good tuning match.

### Pending fixture impact

This is a conservative initial criterion. It catches some noise-floor FPs (e.g., `d4-repeat-01` segment at 4.600s: score=3.0, FR=0.078) but does not yet recover the 3 pending fixtures. Full recovery requires note-band evidence from #66.

| Pending fixture | Current FP score/FR | Caught? |
|----------------|-------------------|---------|
| a4-d4-f4-triad-repeat-01 | 0.9/0.378 (in ignoredRange) | Yes (no event impact) |
| d4-repeat-01 | 3.0/0.078 | Yes |
| e4-g4-b4-triad-repeat-01 | 18.6/0.841 | No (needs #66) |

### Mechanism tests (test_segment_peaks.py)

1. `test_segment_peaks_rejects_weak_primary_with_low_score_and_fundamental_ratio` — verifies rejection
2. `test_segment_peaks_keeps_low_score_primary_with_high_fundamental_ratio` — verifies no false negative
3. `test_segment_peaks_keeps_high_score_primary_with_low_fundamental_ratio` — verifies no false negative

## Related

- #59 (umbrella)
- #65 (this slice)
- #66 (next: note-band evidence analysis)
- #64 (next: collector provenance)

## Test plan

- [x] 287 tests pass (284 existing + 3 new)
- [x] No regressions in completed fixtures
- [x] Rejection fires in practice (d4-repeat-01: 11→10 candidates)
- [ ] Codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)