### PR TITLE
fix: dedup strategy — prefer fine-grained segments, trim estimated ends (#102)

### DIFF
--- a/apps/api/app/transcription.py
+++ b/apps/api/app/transcription.py
@@ -477,6 +477,7 @@ class Segment:
     merged_from: tuple[Segment, ...] = ()
     merge_reason: str = ""
     end_estimated: bool = False
+    trimmed_from: Segment | None = None
 
     def __iter__(self):
         yield self.start_time
@@ -573,11 +574,20 @@ def dedupe_cross_collector_segments(segments: list[Segment]) -> list[Segment]:
             )
             if shorter_duration > 0 and overlap >= shorter_duration * CROSS_COLLECTOR_DEDUP_MIN_OVERLAP_RATIO:
                 # When one side has an estimated end and the other doesn't,
-                # prefer the non-estimated (more precise) segment.
+                # trim the estimated segment's end to the non-estimated
+                # segment's start, preserving the onset portion.
                 if prev.end_estimated and not seg.end_estimated:
-                    deduped[-1] = seg
+                    trimmed_end = seg.start_time
+                    if trimmed_end - prev.start_time >= 0.08:
+                        deduped[-1] = dataclass_replace(prev, end_time=trimmed_end, trimmed_from=prev)
+                        deduped.append(seg)
+                    else:
+                        deduped[-1] = seg  # too short after trim, just replace
                 elif seg.end_estimated and not prev.end_estimated:
-                    pass  # keep prev, drop seg
+                    trimmed_start_for_seg = prev.end_time
+                    if seg.end_time - trimmed_start_for_seg >= 0.08:
+                        deduped.append(dataclass_replace(seg, start_time=trimmed_start_for_seg, trimmed_from=seg))
+                    # else: remaining portion too short, drop seg
                 else:
                     deduped[-1] = _merge_segments(prev, seg, min(prev.start_time, seg.start_time), max(prev.end_time, seg.end_time), reason="cross_collector_overlap")
                 continue
@@ -6525,6 +6535,12 @@ async def transcribe_audio(
             candidate_debug["segmentSource"] = sorted(segment.sources) if segment.sources else ["unknown"]
             if segment.end_estimated:
                 candidate_debug["endEstimated"] = True
+            if segment.trimmed_from:
+                candidate_debug["trimmedFrom"] = {
+                    "startTime": round(segment.trimmed_from.start_time, 6),
+                    "endTime": round(segment.trimmed_from.end_time, 6),
+                    "sources": sorted(segment.trimmed_from.sources),
+                }
             if segment.merged_from:
                 candidate_debug["mergeReason"] = segment.merge_reason
                 candidate_debug["mergedFrom"] = [


### PR DESCRIPTION
## Summary

`dedupe_cross_collector_segments` が粗い estimated segment で fine-grained segment を吸収する問題を修正。BWV147-163 L2 が 53% → 73% exact に改善。

## Changes (3 commits)

### Step 1: attackValidatedGap に max duration cap
`collect_attack_validated_gap_segments` の intermediate segment に `CANDIDATE_PROMOTION_MAX_SEGMENT_DURATION` (0.8s) を適用。4.77s segment の生成を防止。

### Step 2: Segment.end_estimated + dedup preference
- `Segment` に `end_estimated: bool` フィールド追加
- end を推定する collector (attackValidatedGap, terminal系, sparseGapTail, singleOnsetGapHead, terminalTwoOnsetTail) が `end_estimated=True` を設定
- dedup で estimated vs non-estimated が overlap した場合、non-estimated を優先

### Step 3: trim + provenance 保存
- estimated segment を丸ごと drop ではなく、non-estimated の boundary で trim
- 元の segment を `trimmed_from` に保存
- debug 出力に `trimmedFrom`, `endEstimated` を追加

## BWV147-163 Impact

| 指標 | Before (#71 merge後) | After |
|------|---------------------|-------|
| Exact | 138/163 (85%) | **142/163 (87%)** |
| No match | 7 | **5** |
| L2 exact | 53% (8/15) | **73% (11/15)** |

L2 の改善は E20-E22 (G5, A5, G5+E4) の 3 events 回復による。root cause: attackValidatedGap の 4.77s segment が multiOnsetGap の 3 分割を cross_collector_overlap で吸収していた。#71 provenance で特定。

## Test plan

- [x] 299/299 tests pass
- [x] BWV147-163 alignment verified (142/163 exact)
- [x] dedup tests pass (Segment 対応済み)
- [x] Debug output に endEstimated / trimmedFrom が正しく出力される

確認コミット: `d70f632`

🤖 Generated with [Claude Code](https://claude.com/claude-code)