### PR TITLE
fix(ci): limit xdist workers to 2 and add OMP/NUMBA thread limits

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,9 @@ jobs:
         run: uv sync --dev
 
       - name: Run tests
-        run: uv run pytest apps/api/tests -q
+        run: uv run pytest apps/api/tests -q -n 2
         env:
           OPENBLAS_NUM_THREADS: "1"
           MKL_NUM_THREADS: "1"
+          OMP_NUM_THREADS: "1"
+          NUMBA_NUM_THREADS: "1"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,8 +33,9 @@ jobs:
         run: uv sync --dev
 
       - name: Run tests
-        run: uv run pytest apps/api/tests -q -n 2
+        run: uv run pytest apps/api/tests -q
         env:
+          PYTEST_XDIST_AUTO_NUM_WORKERS: "2"
           OPENBLAS_NUM_THREADS: "1"
           MKL_NUM_THREADS: "1"
           OMP_NUM_THREADS: "1"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,9 +33,8 @@ jobs:
         run: uv sync --dev
 
       - name: Run tests
-        run: uv run pytest apps/api/tests -q
+        run: uv run pytest apps/api/tests -q -n 2
         env:
-          PYTEST_XDIST_AUTO_NUM_WORKERS: "2"
           OPENBLAS_NUM_THREADS: "1"
           MKL_NUM_THREADS: "1"
           OMP_NUM_THREADS: "1"

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ artifacts/
 .tmp-venv/
 pytest-cache-files-*/
 apps/api/tests/.cache/
+*.egg-info/


### PR DESCRIPTION
The CI has been failing intermittently with worker crashes (segfaults)
in numba/LLVM JIT during librosa onset detection. Root cause is memory
pressure from pytest-xdist spawning too many workers (`-n auto` uses
all available vCPUs), each loading the full scientific stack
(numpy+scipy+numba+librosa).

Changes:
- Pin xdist workers to 2 (`-n 2`) instead of auto-detecting vCPUs,
  reducing peak memory from ~4 concurrent processes to 2
- Add OMP_NUM_THREADS=1 to prevent OpenMP threading inside workers
- Add NUMBA_NUM_THREADS=1 to prevent numba parallel execution

OPENBLAS_NUM_THREADS and MKL_NUM_THREADS were already set in PR #176
but were insufficient alone because OMP and numba threading were still
unrestricted.

https://claude.ai/code/session_01HDodqmaLiocJB8pZWzwXkQ