### PR TITLE
Add narrow-FFT time cache across rescue passes

### DIFF
--- a/apps/api/app/transcription/events.py
+++ b/apps/api/app/transcription/events.py
@@ -1433,6 +1433,7 @@ def recover_pre_segment_attack_via_narrow_fft(
     onset_consumed_tolerance: float = NARROW_FFT_PRE_SEGMENT_ONSET_CONSUMED_TOLERANCE,
     decay_min_ratio: float = NARROW_FFT_PRE_SEGMENT_DECAY_MIN_RATIO,
     bg_dominance_ratio: float = NARROW_FFT_PRE_SEGMENT_BG_DOMINANCE_RATIO,
+    narrow_fft_cache: dict[tuple[int, float], dict[str, tuple[float, float, float]] | None] | None = None,
 ) -> list[RawEvent]:
     """Recover a chord note that attacks in the gap before an event from
     a broadband onset that the segmenter did not materialize (#153
@@ -1540,7 +1541,7 @@ def recover_pre_segment_attack_via_narrow_fft(
         onset_time = candidates_in_window[-1]
 
         narrow_scores = measure_narrow_fft_note_scores(
-            audio, sample_rate, onset_time, tuning,
+            audio, sample_rate, onset_time, tuning, cache=narrow_fft_cache,
         )
         if narrow_scores is None:
             recovered.append(event)
@@ -1549,7 +1550,7 @@ def recover_pre_segment_attack_via_narrow_fft(
         # pass should only rescue notes whose energy is DECAYING
         # SLOWLY from the unconsumed onset to the segment start.
         segment_start_scores = measure_narrow_fft_note_scores(
-            audio, sample_rate, event.start_time, tuning,
+            audio, sample_rate, event.start_time, tuning, cache=narrow_fft_cache,
         )
 
         existing_names = {note.note_name for note in event.notes}
@@ -1673,6 +1674,7 @@ def recover_spread_chord_via_segment_start_probe(
     onset_consumed_tolerance: float = NARROW_FFT_PRE_SEGMENT_ONSET_CONSUMED_TOLERANCE,
     rise_min_ratio: float = NARROW_FFT_SPREAD_CHORD_RISE_MIN_RATIO,
     bg_dominance_ratio: float = NARROW_FFT_SPREAD_CHORD_BG_DOMINANCE_RATIO,
+    narrow_fft_cache: dict[tuple[int, float], dict[str, tuple[float, float, float]] | None] | None = None,
 ) -> list[RawEvent]:
     """Recover a chord note whose attack falls between the broadband
     onset and the segment start (spread / rolled chord, #167 Phase C).
@@ -1744,7 +1746,7 @@ def recover_spread_chord_via_segment_start_probe(
 
         # Probe at segment start — spread-chord notes are established here.
         segment_start_scores = measure_narrow_fft_note_scores(
-            audio, sample_rate, event.start_time, tuning,
+            audio, sample_rate, event.start_time, tuning, cache=narrow_fft_cache,
         )
         if segment_start_scores is None:
             recovered.append(event)
@@ -1752,7 +1754,7 @@ def recover_spread_chord_via_segment_start_probe(
 
         # Probe at onset time for the rise discriminator (gate 5).
         onset_scores = measure_narrow_fft_note_scores(
-            audio, sample_rate, onset_time, tuning,
+            audio, sample_rate, onset_time, tuning, cache=narrow_fft_cache,
         )
 
         existing_names = {note.note_name for note in event.notes}

--- a/apps/api/app/transcription/peaks.py
+++ b/apps/api/app/transcription/peaks.py
@@ -1805,7 +1805,11 @@ def measure_narrow_fft_note_scores(
     not surface in the ranked hypotheses are absent from the returned dict
     (callers should treat their values as 0.0).
     """
-    cache_key = (int(round(sub_onset_time * sample_rate)), float(window_seconds))
+    # Must match `_narrow_fft_at_sub_onset`'s `center_sample` quantization
+    # (truncation via int()); using round() here would alias distinct centers
+    # to the same key and return note scores from a different FFT window.
+    center_sample = int(sub_onset_time * sample_rate)
+    cache_key = (center_sample, float(window_seconds))
     if cache is not None and cache_key in cache:
         return cache[cache_key]
 

--- a/apps/api/app/transcription/peaks.py
+++ b/apps/api/app/transcription/peaks.py
@@ -1787,6 +1787,7 @@ def measure_narrow_fft_note_scores(
     tuning: InstrumentTuning,
     *,
     window_seconds: float = NARROW_FFT_WINDOW_SECONDS,
+    cache: dict[tuple[int, float], dict[str, tuple[float, float, float]] | None] | None = None,
 ) -> dict[str, tuple[float, float, float]] | None:
     """Return ``{note_name: (fundamental_energy, score, fundamental_ratio)}``
     from a narrow FFT centred on *sub_onset_time*.
@@ -1804,12 +1805,19 @@ def measure_narrow_fft_note_scores(
     not surface in the ranked hypotheses are absent from the returned dict
     (callers should treat their values as 0.0).
     """
+    cache_key = (int(round(sub_onset_time * sample_rate)), float(window_seconds))
+    if cache is not None and cache_key in cache:
+        return cache[cache_key]
+
     spectral = _narrow_fft_at_sub_onset(
         audio, sample_rate, sub_onset_time, tuning,
         window_seconds=window_seconds,
     )
     if spectral is None:
+        if cache is not None:
+            cache[cache_key] = None
         return None
+
     by_name: dict[str, tuple[float, float, float]] = {}
     for hypothesis in spectral.ranked:
         name = hypothesis.candidate.note_name
@@ -1819,6 +1827,8 @@ def measure_narrow_fft_note_scores(
                 float(hypothesis.score),
                 float(hypothesis.fundamental_ratio),
             )
+    if cache is not None:
+        cache[cache_key] = by_name
     return by_name
 
 

--- a/apps/api/app/transcription/pipeline.py
+++ b/apps/api/app/transcription/pipeline.py
@@ -429,6 +429,9 @@ async def transcribe_audio(
                 ))
 
     processed_events = raw_events
+    narrow_fft_time_cache: dict[
+        tuple[int, float], dict[str, tuple[float, float, float]] | None
+    ] = {}
     _pp("suppress_low_confidence_dyad_transients", suppress_low_confidence_dyad_transients)
     _pp("suppress_onset_decaying_carryover", suppress_onset_decaying_carryover)
     _pp("collapse_same_start_primary_singletons", collapse_same_start_primary_singletons)
@@ -482,7 +485,8 @@ async def transcribe_audio(
     # the gap and decays before the next segment starts.
     _pp("recover_pre_segment_attack_via_narrow_fft",
         recover_pre_segment_attack_via_narrow_fft,
-        audio, sample_rate, tuning, all_onset_times, noise_floor=noise_floor)
+        audio, sample_rate, tuning, all_onset_times,
+        noise_floor=noise_floor, narrow_fft_cache=narrow_fft_time_cache)
     # #167 Phase C spread-chord rescue: recover notes that attacked
     # between the broadband onset and the segment start (rolled /
     # arpeggiated chords).  Unlike Phase B, these notes are RISING
@@ -491,10 +495,12 @@ async def transcribe_audio(
     # (e.g. G-low E136: B3 then G3).
     _pp("recover_spread_chord_via_segment_start_probe",
         recover_spread_chord_via_segment_start_probe,
-        audio, sample_rate, tuning, all_onset_times, noise_floor=noise_floor)
+        audio, sample_rate, tuning, all_onset_times,
+        noise_floor=noise_floor, narrow_fft_cache=narrow_fft_time_cache)
     _pp("recover_spread_chord_via_segment_start_probe_2",
         recover_spread_chord_via_segment_start_probe,
-        audio, sample_rate, tuning, all_onset_times, noise_floor=noise_floor)
+        audio, sample_rate, tuning, all_onset_times,
+        noise_floor=noise_floor, narrow_fft_cache=narrow_fft_time_cache)
     _pp("collapse_late_descending_step_handoffs", collapse_late_descending_step_handoffs)
 
     def _mp(name: str, fn, *args, **kwargs) -> list[RawEvent]:

--- a/apps/api/tests/test_narrow_fft_time_cache.py
+++ b/apps/api/tests/test_narrow_fft_time_cache.py
@@ -45,3 +45,38 @@ def test_measure_narrow_fft_note_scores_reuses_time_cache():
     assert first == fake_result
     assert second == fake_result
     assert mock_fft.call_count == 1
+
+
+def test_cache_key_matches_narrow_fft_center_sample_quantization():
+    """Distinct ``sub_onset_time`` values that truncate to different
+    ``center_sample`` indices must not share a cache entry, even when
+    ``round()`` would alias them together.
+
+    Under the old ``int(round(...))`` key, both times below rounded to
+    44100, hiding the off-by-one sample shift in the actual FFT window.
+    """
+    audio = np.zeros(44100, dtype=np.float32)
+    tuning = _tuning()
+    sample_rate = 44100
+    cache: dict[tuple[int, float], dict[str, tuple[float, float, float]] | None] = {}
+
+    t_low = 44099.6 / sample_rate  # truncates to 44099, rounds to 44100
+    t_high = 44100.4 / sample_rate  # truncates to 44100, rounds to 44100
+    assert int(t_low * sample_rate) != int(t_high * sample_rate)
+
+    class _Hypothesis:
+        def __init__(self):
+            self.candidate = type("Candidate", (), {"note_name": "A4"})()
+            self.fundamental_energy = 42.0
+            self.score = 7.0
+            self.fundamental_ratio = 0.99
+
+    fake_spectral = type("Spectral", (), {"ranked": [_Hypothesis()]})()
+    with patch(
+        "app.transcription.peaks._narrow_fft_at_sub_onset",
+        return_value=fake_spectral,
+    ) as mock_fft:
+        measure_narrow_fft_note_scores(audio, sample_rate, t_low, tuning, cache=cache)
+        measure_narrow_fft_note_scores(audio, sample_rate, t_high, tuning, cache=cache)
+
+    assert mock_fft.call_count == 2

--- a/apps/api/tests/test_narrow_fft_time_cache.py
+++ b/apps/api/tests/test_narrow_fft_time_cache.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import numpy as np
+
+from app.models import InstrumentTuning, TuningNote
+from app.transcription.peaks import measure_narrow_fft_note_scores
+
+
+def _tuning() -> InstrumentTuning:
+    return InstrumentTuning(
+        id="cache-test",
+        name="cache-test",
+        key_count=1,
+        notes=[TuningNote(key=1, note_name="A4", frequency=440.0)],
+    )
+
+
+def test_measure_narrow_fft_note_scores_reuses_time_cache():
+    audio = np.zeros(44100, dtype=np.float32)
+    tuning = _tuning()
+    cache: dict[tuple[int, float], dict[str, tuple[float, float, float]] | None] = {}
+    fake_result = {"A4": (42.0, 7.0, 0.99)}
+
+    class _Hypothesis:
+        def __init__(self):
+            self.candidate = type("Candidate", (), {"note_name": "A4"})()
+            self.fundamental_energy = 42.0
+            self.score = 7.0
+            self.fundamental_ratio = 0.99
+
+    fake_spectral = type("Spectral", (), {"ranked": [_Hypothesis()]})()
+    with patch(
+        "app.transcription.peaks._narrow_fft_at_sub_onset",
+        return_value=fake_spectral,
+    ) as mock_fft:
+        first = measure_narrow_fft_note_scores(
+            audio, 44100, 0.5, tuning, cache=cache,
+        )
+        second = measure_narrow_fft_note_scores(
+            audio, 44100, 0.5, tuning, cache=cache,
+        )
+
+    assert first == fake_result
+    assert second == fake_result
+    assert mock_fft.call_count == 1

--- a/apps/api/tests/test_spread_chord_rescue.py
+++ b/apps/api/tests/test_spread_chord_rescue.py
@@ -112,7 +112,7 @@ class TestTruePositive:
             "B4": (12.0, 18.0, 0.99),
         }
 
-        def mock_narrow_fft(audio, sr, time, tuning):
+        def mock_narrow_fft(audio, sr, time, tuning, **kwargs):
             if abs(time - 10.4) < 0.01:
                 return seg_scores
             if abs(time - 10.25) < 0.01:
@@ -155,7 +155,7 @@ class TestGate1BackwardGain:
         seg_scores = {"B3": (30.0, 43.0, 0.87), "D4": (35.0, 50.0, 0.97), "B4": (8.0, -4.0, 0.86)}
         onset_scores = {"B3": (0.8, 1.0, 0.11)}
 
-        def mock_narrow_fft(audio, sr, time, tuning):
+        def mock_narrow_fft(audio, sr, time, tuning, **kwargs):
             if abs(time - 10.4) < 0.01:
                 return seg_scores
             if abs(time - 10.25) < 0.01:
@@ -193,7 +193,7 @@ class TestGate2BgDominance:
         seg_scores = {"B3": (30.0, 43.0, 0.87), "D4": (35.0, 50.0, 0.97), "B4": (8.0, -4.0, 0.86)}
         onset_scores = {"B3": (0.8, 1.0, 0.11)}
 
-        def mock_narrow_fft(audio, sr, time, tuning):
+        def mock_narrow_fft(audio, sr, time, tuning, **kwargs):
             if abs(time - 10.4) < 0.01:
                 return seg_scores
             if abs(time - 10.25) < 0.01:
@@ -237,7 +237,7 @@ class TestGate5RiseDiscriminator:
         seg_scores = {"B3": (30.0, 43.0, 0.87), "D4": (35.0, 50.0, 0.97), "B4": (8.0, -4.0, 0.86)}
         onset_scores = {"B3": (28.0, 40.0, 0.85)}  # rise = 30/28 ≈ 1.07 < 2.0
 
-        def mock_narrow_fft(audio, sr, time, tuning):
+        def mock_narrow_fft(audio, sr, time, tuning, **kwargs):
             if abs(time - 10.4) < 0.01:
                 return seg_scores
             if abs(time - 10.25) < 0.01:
@@ -282,7 +282,7 @@ class TestGate6Dissonance:
         }
         onset_scores = {"C4": (1.0, 1.5, 0.20)}
 
-        def mock_narrow_fft(audio, sr, time, tuning):
+        def mock_narrow_fft(audio, sr, time, tuning, **kwargs):
             if abs(time - 10.4) < 0.01:
                 return seg_scores
             if abs(time - 10.25) < 0.01:


### PR DESCRIPTION
### Motivation
- Reduce duplicated narrow-FFT work across rescue passes (Phase B / Phase C) by reusing results when probing the same time/window, improving performance with minimal behavioral change.

### Description
- Add an optional `cache` parameter to `measure_narrow_fft_note_scores` that keys on `(int(round(sub_onset_time * sample_rate)), window_seconds)` and stores `None` or the computed `{note_name: (fund_e, score, fr)}` map to avoid re-running the FFT for identical probes (`apps/api/app/transcription/peaks.py`).
- Thread a `narrow_fft_cache` argument through `recover_pre_segment_attack_via_narrow_fft` and `recover_spread_chord_via_segment_start_probe` and use the cache when calling `measure_narrow_fft_note_scores` (`apps/api/app/transcription/events.py`).
- Create a shared `narrow_fft_time_cache` in `transcribe_audio` and pass it to the Phase B + both Phase C invocations so passes share results across event passes (`apps/api/app/transcription/pipeline.py`).
- Add a focused mechanism test `apps/api/tests/test_narrow_fft_time_cache.py` to verify the cache prevents duplicate `_narrow_fft_at_sub_onset` calls, and update `test_spread_chord_rescue.py` mocks to accept the new keyword argument.

### Testing
- Ran `uv run pytest apps/api/tests/test_narrow_fft_time_cache.py -q` and it passed (1 passed).
- Ran `uv run pytest apps/api/tests/test_spread_chord_rescue.py -q` and it passed (all tests in that file passed after mock updates).
- Ran the two tests together (`uv run pytest apps/api/tests/test_narrow_fft_time_cache.py apps/api/tests/test_spread_chord_rescue.py -q`) and observed `9 passed`.
- Attempting the full `uv run pytest apps/api/tests -q` in this environment triggered intermittent segmentation faults in the `librosa.onset_detect` / numba path; this appears to be an environment-related issue and is unrelated to the cache change itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de2983c8a4833296ddd4e77ce65b55)