### PR TITLE
Stabilize GitHub Actions pytest execution by disabling xdist and numba JIT in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,9 +33,10 @@ jobs:
         run: uv sync --dev
 
       - name: Run tests
-        run: uv run pytest apps/api/tests -q -n 2
+        run: uv run pytest apps/api/tests -q
         env:
           OPENBLAS_NUM_THREADS: "1"
           MKL_NUM_THREADS: "1"
           OMP_NUM_THREADS: "1"
           NUMBA_NUM_THREADS: "1"
+          NUMBA_DISABLE_JIT: "1"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,6 @@
 [pytest]
 pythonpath = . apps/api
-addopts = -m "not ablation" -n auto
-required_plugins = pytest-xdist
+addopts = -m "not ablation"
 markers =
     manual_capture: tests that exercise manual audio capture fixtures
     slow: long-running regression and integration tests


### PR DESCRIPTION
### Motivation
- CI runs were intermittently crashing with native `SIGSEGV` errors in tempo/beat paths that exercise `librosa`/`numba` when pytest executed tests in parallel workers. 
- The change aims to make test execution deterministic and robust on GitHub Actions under Python 3.13 by reducing exposure to native-code instability.

### Description
- Remove forced xdist parallelism from default pytest options by deleting `-n auto` and `required_plugins = pytest-xdist` from `pytest.ini` so local/CI test commands do not assume xdist is available. 
- Update the GitHub Actions test step to run `uv run pytest apps/api/tests -q` (no `-n` worker flag) to avoid spawning parallel worker processes in CI. 
- Add `NUMBA_DISABLE_JIT=1` to the CI test environment to disable numba JIT compilation in Actions and reduce native-code crash surface while keeping full test coverage.

### Testing
- Reproduced the original intermittent failure pattern when running with xdist: a run showed worker crashes/segfaults (10 failed, 354 passed) under parallel execution. 
- Ran the full suite without xdist using `uv run pytest apps/api/tests -q`, which completed successfully with `379 passed, 180 deselected` (duration ~17:02).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de36563db08332ac498408b4dcaf3a)