### PR TITLE
Stabilize GitHub Actions by running pytest without xdist workers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
         run: uv sync --dev
 
       - name: Run tests
-        run: uv run pytest apps/api/tests -q -n 2
+        run: uv run pytest apps/api/tests -q
         env:
           OPENBLAS_NUM_THREADS: "1"
           MKL_NUM_THREADS: "1"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 pythonpath = . apps/api
-addopts = -m "not ablation" -n auto
+addopts = -m "not ablation"
 required_plugins = pytest-xdist
 markers =
     manual_capture: tests that exercise manual audio capture fixtures


### PR DESCRIPTION
### Motivation
- CI runs on GitHub Actions were intermittently crashing with xdist worker deaths and `SIGSEGV` during `librosa`/`numba` execution, making the test job flaky under Python 3.13. 
- Running the API test suite in a single process avoids the unstable multi-worker execution mode while preserving the same test coverage.

### Description
- Remove implicit xdist parallelism by deleting `-n auto` from the `addopts` in `pytest.ini` so local/CI runs default to a single process. 
- Update the workflow command in `.github/workflows/test.yml` to run `uv run pytest apps/api/tests -q` (removed the explicit `-n 2`), keeping the thread-limiting env vars (`OPENBLAS_NUM_THREADS`, `MKL_NUM_THREADS`, `OMP_NUM_THREADS`, `NUMBA_NUM_THREADS`).
- Keep `pytest-xdist` listed as a required plugin so parallel runs remain opt-in for developers who explicitly enable them.

### Testing
- Ran the failing-area smoke targets with `uv run pytest apps/api/tests/test_explain_manual_capture.py apps/api/tests/test_manual_capture_completed.py apps/api/tests/test_synthesized_regression.py -q`, which completed with `41 passed`.
- The targeted single-process runs resolved the prior worker-crash reproduction for these tests and returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de36563db08332ac498408b4dcaf3a)