### PR TITLE
feat: 確認・修正 (review) ページ — 採譜結果のユーザー修正と corrections 永続化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 .next/
+.next-dev/
 dist/
 build/
 .pytest_cache/

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 from fastapi import FastAPI, File, Form, HTTPException, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from .fingerprints import git_head_sha, kalimba_dsp_fingerprint, recognizer_fingerprint
 from .models import CorrectionsPayload, InstrumentTuning, TranscriptionResult
@@ -24,6 +24,7 @@ from .storage import (
     load_corrections,
     load_memo,
     load_response,
+    quarantine_corrections,
     save_corrections,
     save_memo,
     save_transaction,
@@ -230,7 +231,17 @@ def get_transcription_corrections(transaction_id: str) -> dict:
     _validate_transaction_id(transaction_id)
     if not transaction_exists(transaction_id):
         raise HTTPException(status_code=404, detail="Transaction not found.")
-    return {"corrections": load_corrections(transaction_id)}
+    raw = load_corrections(transaction_id)
+    if raw is None:
+        return {"corrections": None}
+    try:
+        validated = CorrectionsPayload.model_validate(raw)
+    except ValidationError:
+        # 壊れた/互換性のないファイルを返すとクライアントが誤動作し、次の保存で
+        # 原本ごと上書きされる。退避 (.invalid) でデータを保全しつつ「無し」を返す。
+        quarantine_corrections(transaction_id)
+        return {"corrections": None}
+    return {"corrections": validated.model_dump(by_alias=True)}
 
 
 @app.put("/api/transcriptions/{transaction_id}/corrections")

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import re
+from datetime import datetime, timezone
 
 from fastapi import FastAPI, File, Form, HTTPException, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
@@ -10,7 +11,7 @@ from fastapi.responses import FileResponse
 from pydantic import BaseModel
 
 from .fingerprints import git_head_sha, kalimba_dsp_fingerprint, recognizer_fingerprint
-from .models import InstrumentTuning, TranscriptionResult
+from .models import CorrectionsPayload, InstrumentTuning, TranscriptionResult
 from .storage import (
     compute_audio_sha256,
     find_transaction_by_hash_and_tuning,
@@ -20,8 +21,10 @@ from .storage import (
     list_recent_transactions,
     list_transactions_by_hash,
     load_audio_path,
+    load_corrections,
     load_memo,
     load_response,
+    save_corrections,
     save_memo,
     save_transaction,
     transaction_exists,
@@ -220,3 +223,22 @@ def put_transcription_memo(transaction_id: str, payload: MemoPayload) -> dict[st
         raise HTTPException(status_code=404, detail="Transaction not found.")
     save_memo(transaction_id, payload.memo)
     return {"memo": payload.memo}
+
+
+@app.get("/api/transcriptions/{transaction_id}/corrections")
+def get_transcription_corrections(transaction_id: str) -> dict:
+    _validate_transaction_id(transaction_id)
+    if not transaction_exists(transaction_id):
+        raise HTTPException(status_code=404, detail="Transaction not found.")
+    return {"corrections": load_corrections(transaction_id)}
+
+
+@app.put("/api/transcriptions/{transaction_id}/corrections")
+def put_transcription_corrections(transaction_id: str, payload: CorrectionsPayload) -> dict:
+    _validate_transaction_id(transaction_id)
+    if not transaction_exists(transaction_id):
+        raise HTTPException(status_code=404, detail="Transaction not found.")
+    document = payload.model_dump(by_alias=True)
+    document["updatedAt"] = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    save_corrections(transaction_id, document)
+    return {"corrections": document}

--- a/apps/api/app/models.py
+++ b/apps/api/app/models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -96,13 +96,13 @@ class CorrectionEvent(BaseModel):
     """
     time_sec: float = Field(alias="timeSec")
     notes: list[str] = Field(min_length=1)
-    origin: str = "recognizer"  # recognizer | edited | inserted-slot | inserted-manual
+    origin: Literal["recognizer", "edited", "inserted-slot", "inserted-manual"] = "recognizer"
 
     model_config = {"populate_by_name": True}
 
 
 class CorrectionsPayload(BaseModel):
-    version: int = 1
+    version: Literal[1] = 1
     updated_at: str | None = Field(default=None, alias="updatedAt")
     events: list[CorrectionEvent]
 

--- a/apps/api/app/models.py
+++ b/apps/api/app/models.py
@@ -88,6 +88,27 @@ class CandidateSlot(BaseModel):
     model_config = {"populate_by_name": True}
 
 
+class CorrectionEvent(BaseModel):
+    """One event in the user-corrected timeline (review UI).
+
+    Stores note names + absolute seconds so a saved correction can be promoted
+    to ground_truth.json (same time/notes vocabulary) without transformation.
+    """
+    time_sec: float = Field(alias="timeSec")
+    notes: list[str] = Field(min_length=1)
+    origin: str = "recognizer"  # recognizer | edited | inserted-slot | inserted-manual
+
+    model_config = {"populate_by_name": True}
+
+
+class CorrectionsPayload(BaseModel):
+    version: int = 1
+    updated_at: str | None = Field(default=None, alias="updatedAt")
+    events: list[CorrectionEvent]
+
+    model_config = {"populate_by_name": True}
+
+
 class NotationViews(BaseModel):
     western: list[str]
     numbered: list[str]

--- a/apps/api/app/storage.py
+++ b/apps/api/app/storage.py
@@ -213,5 +213,12 @@ def load_corrections(transaction_id: str) -> dict | None:
         return None
 
 
+def quarantine_corrections(transaction_id: str) -> None:
+    """不正な corrections.json を .invalid に退避する (データは保全しつつ「無し」扱いに)。"""
+    corrections_path = get_transaction_dir(transaction_id) / "corrections.json"
+    if corrections_path.exists():
+        corrections_path.replace(corrections_path.with_suffix(".json.invalid"))
+
+
 def transaction_exists(transaction_id: str) -> bool:
     return get_transaction_dir(transaction_id).exists()

--- a/apps/api/app/storage.py
+++ b/apps/api/app/storage.py
@@ -210,6 +210,9 @@ def load_corrections(transaction_id: str) -> dict | None:
     try:
         return json.loads(corrections_path.read_text(encoding="utf-8"))
     except json.JSONDecodeError:
+        # 壊れた JSON (partial write 等) はスキーマ検証層に届かないため、
+        # ここで退避しないと次の保存で原本ごと上書きされる
+        quarantine_corrections(transaction_id)
         return None
 
 

--- a/apps/api/app/storage.py
+++ b/apps/api/app/storage.py
@@ -195,5 +195,23 @@ def load_memo(transaction_id: str) -> str | None:
     return memo_path.read_text(encoding="utf-8")
 
 
+def save_corrections(transaction_id: str, payload: dict) -> None:
+    tx_dir = get_transaction_dir(transaction_id)
+    tx_dir.mkdir(parents=True, exist_ok=True)
+    (tx_dir / "corrections.json").write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+
+def load_corrections(transaction_id: str) -> dict | None:
+    corrections_path = get_transaction_dir(transaction_id) / "corrections.json"
+    if not corrections_path.exists():
+        return None
+    try:
+        return json.loads(corrections_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None
+
+
 def transaction_exists(transaction_id: str) -> bool:
     return get_transaction_dir(transaction_id).exists()

--- a/apps/api/tests/test_corrections.py
+++ b/apps/api/tests/test_corrections.py
@@ -1,0 +1,90 @@
+"""Corrections endpoint tests (review UI persistence).
+
+corrections.json stores the user-verified event timeline in the same
+time/notes vocabulary as ground_truth.json so saved corrections can be
+promoted to F1-benchmark ground truth without transformation.
+"""
+
+from io import BytesIO
+import json
+
+import numpy as np
+import soundfile as sf
+
+from conftest import client
+
+
+def _make_audio_bytes() -> bytes:
+    sample_rate = 44100
+    t = np.linspace(0, 0.5, int(sample_rate * 0.5), endpoint=False)
+    wave_data = 0.4 * np.sin(2 * np.pi * 261.63 * t) * np.exp(-4 * t)
+    buffer = BytesIO()
+    sf.write(buffer, wave_data, sample_rate, format="WAV")
+    return buffer.getvalue()
+
+
+def _create_transaction() -> str:
+    tuning = {"name": "Test 17-C", "notes": [{"noteName": "C4"}]}
+    response = client.post(
+        "/api/transcriptions",
+        data={"tuning": json.dumps(tuning), "force": "true"},
+        files={"file": ("audio.wav", _make_audio_bytes(), "audio/wav")},
+    )
+    assert response.status_code == 200
+    return response.json()["transactionId"]
+
+
+def test_corrections_missing_returns_null():
+    tid = _create_transaction()
+    response = client.get(f"/api/transcriptions/{tid}/corrections")
+    assert response.status_code == 200
+    assert response.json() == {"corrections": None}
+
+
+def test_corrections_roundtrip():
+    tid = _create_transaction()
+    payload = {
+        "version": 1,
+        "events": [
+            {"timeSec": 1.05, "notes": ["C4"], "origin": "recognizer"},
+            {"timeSec": 2.5, "notes": ["D4", "D5"], "origin": "edited"},
+            {"timeSec": 3.75, "notes": ["E4"], "origin": "inserted-manual"},
+        ],
+    }
+    put_response = client.put(f"/api/transcriptions/{tid}/corrections", json=payload)
+    assert put_response.status_code == 200
+    saved = put_response.json()["corrections"]
+    assert saved["version"] == 1
+    assert saved["updatedAt"]
+    assert [e["notes"] for e in saved["events"]] == [["C4"], ["D4", "D5"], ["E4"]]
+
+    get_response = client.get(f"/api/transcriptions/{tid}/corrections")
+    assert get_response.status_code == 200
+    assert get_response.json()["corrections"] == saved
+
+
+def test_corrections_overwrite_replaces_previous():
+    tid = _create_transaction()
+    first = {"version": 1, "events": [{"timeSec": 1.0, "notes": ["C4"]}]}
+    second = {"version": 1, "events": []}
+    client.put(f"/api/transcriptions/{tid}/corrections", json=first)
+    client.put(f"/api/transcriptions/{tid}/corrections", json=second)
+    response = client.get(f"/api/transcriptions/{tid}/corrections")
+    assert response.json()["corrections"]["events"] == []
+
+
+def test_corrections_rejects_empty_notes():
+    tid = _create_transaction()
+    payload = {"version": 1, "events": [{"timeSec": 1.0, "notes": []}]}
+    response = client.put(f"/api/transcriptions/{tid}/corrections", json=payload)
+    assert response.status_code == 422
+
+
+def test_corrections_unknown_transaction_404():
+    missing_id = "00000000-0000-0000-0000-000000000000"
+    assert client.get(f"/api/transcriptions/{missing_id}/corrections").status_code == 404
+    payload = {"version": 1, "events": []}
+    assert (
+        client.put(f"/api/transcriptions/{missing_id}/corrections", json=payload).status_code
+        == 404
+    )

--- a/apps/api/tests/test_corrections.py
+++ b/apps/api/tests/test_corrections.py
@@ -116,6 +116,22 @@ def test_corrections_invalid_file_is_quarantined_on_read():
     assert (tx_dir / "corrections.json.invalid").exists()
 
 
+def test_corrections_malformed_json_is_quarantined_on_read():
+    from app.storage import get_transaction_dir
+
+    tid = _create_transaction()
+    tx_dir = get_transaction_dir(tid)
+    corrections_path = tx_dir / "corrections.json"
+    # partial write 等で JSON として壊れたファイル
+    corrections_path.write_text('{"version": 1, "events": [', encoding="utf-8")
+
+    response = client.get(f"/api/transcriptions/{tid}/corrections")
+    assert response.status_code == 200
+    assert response.json() == {"corrections": None}
+    assert not corrections_path.exists()
+    assert (tx_dir / "corrections.json.invalid").exists()
+
+
 def test_corrections_unknown_transaction_404():
     missing_id = "00000000-0000-0000-0000-000000000000"
     assert client.get(f"/api/transcriptions/{missing_id}/corrections").status_code == 404

--- a/apps/api/tests/test_corrections.py
+++ b/apps/api/tests/test_corrections.py
@@ -80,6 +80,42 @@ def test_corrections_rejects_empty_notes():
     assert response.status_code == 422
 
 
+def test_corrections_rejects_unknown_origin():
+    tid = _create_transaction()
+    payload = {"version": 1, "events": [{"timeSec": 1.0, "notes": ["C4"], "origin": "guessed"}]}
+    response = client.put(f"/api/transcriptions/{tid}/corrections", json=payload)
+    assert response.status_code == 422
+
+
+def test_corrections_rejects_unsupported_version():
+    tid = _create_transaction()
+    payload = {"version": 2, "events": [{"timeSec": 1.0, "notes": ["C4"]}]}
+    response = client.put(f"/api/transcriptions/{tid}/corrections", json=payload)
+    assert response.status_code == 422
+
+
+def test_corrections_invalid_file_is_quarantined_on_read():
+    from app.storage import get_transaction_dir
+
+    tid = _create_transaction()
+    tx_dir = get_transaction_dir(tid)
+    corrections_path = tx_dir / "corrections.json"
+    # スキーマ非互換 (origin typo) のファイルを直接置く
+    corrections_path.write_text(
+        json.dumps(
+            {"version": 1, "events": [{"timeSec": 1.0, "notes": ["C4"], "origin": "typo"}]}
+        ),
+        encoding="utf-8",
+    )
+
+    response = client.get(f"/api/transcriptions/{tid}/corrections")
+    assert response.status_code == 200
+    assert response.json() == {"corrections": None}
+    # 原本は .invalid に退避され、データは失われない
+    assert not corrections_path.exists()
+    assert (tx_dir / "corrections.json.invalid").exists()
+
+
 def test_corrections_unknown_transaction_404():
     missing_id = "00000000-0000-0000-0000-000000000000"
     assert client.get(f"/api/transcriptions/{missing_id}/corrections").status_code == 404

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -3,6 +3,9 @@ import type { NextConfig } from "next";
 const API_PROXY_TARGET = process.env.API_PROXY_TARGET ?? "http://localhost:8000";
 
 const nextConfig: NextConfig = {
+  // 本番 (next start) は .next を serve する。ブランチ検証用の dev server は
+  // NEXT_DIST_DIR=.next-dev で分離し、本番ビルド成果物 (.next) に触れないこと。
+  distDir: process.env.NEXT_DIST_DIR ?? ".next",
   experimental: {
     globalNotFound: true,
   },

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1558,3 +1558,400 @@ button:disabled {
     font-size: 0.75rem;
   }
 }
+
+/* ===== Review editor (/score/[id]/review) — 工房 (atelier) tone ===== */
+
+.review-shell {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 16px 16px 96px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.review-header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--line);
+}
+
+.review-header-row {
+  display: flex;
+  align-items: baseline;
+  gap: 14px;
+}
+
+.review-back-link {
+  color: var(--accent-strong);
+  text-decoration: none;
+  font-size: 0.9rem;
+  white-space: nowrap;
+}
+
+.review-title {
+  margin: 0;
+  font-family: var(--font-heading);
+  font-size: 1.35rem;
+  letter-spacing: 0.04em;
+}
+
+.review-subtitle {
+  margin: 0;
+  font-size: 0.85rem;
+}
+
+.review-playback {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 12px;
+  margin: 0 -4px;
+  background: color-mix(in srgb, var(--bg-alt) 88%, transparent);
+  backdrop-filter: blur(6px);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  box-shadow: 0 6px 18px rgba(30, 31, 31, 0.07);
+}
+
+.review-audio {
+  width: 100%;
+}
+
+.review-insert-control {
+  display: flex;
+}
+
+.review-score {
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: var(--bg-alt);
+  padding: 10px;
+  overflow-x: auto;
+}
+
+/* timeline: 左に真鍮色のレール、各カードが tine のようにぶら下がる */
+.review-timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  position: relative;
+  padding-left: 14px;
+}
+
+.review-timeline::before {
+  content: "";
+  position: absolute;
+  left: 3px;
+  top: 8px;
+  bottom: 8px;
+  width: 2px;
+  background: linear-gradient(180deg, rgba(176, 141, 62, 0.65), rgba(176, 141, 62, 0.15));
+  border-radius: 1px;
+}
+
+.review-card {
+  position: relative;
+  border: 1px solid var(--line);
+  border-left: 4px solid var(--accent);
+  border-radius: 12px;
+  background: var(--bg-alt);
+  overflow: hidden;
+  transition: box-shadow 0.18s ease, transform 0.18s ease;
+}
+
+.review-card::before {
+  content: "";
+  position: absolute;
+  left: -14px;
+  top: 18px;
+  width: 10px;
+  height: 2px;
+  background: rgba(176, 141, 62, 0.55);
+}
+
+.review-card.selected {
+  box-shadow: 0 8px 22px rgba(15, 95, 103, 0.16);
+  transform: translateY(-1px);
+}
+
+.review-card-edited,
+.review-card-inserted-slot,
+.review-card-inserted-manual {
+  border-left-color: #b08d3e;
+}
+
+.review-card.removed {
+  opacity: 0.55;
+  border-left-color: var(--muted);
+}
+
+.review-card.removed .review-card-notes {
+  text-decoration: line-through;
+}
+
+.review-card-slot {
+  border-style: dashed;
+  border-left: 4px dashed rgba(176, 141, 62, 0.7);
+  background: color-mix(in srgb, var(--bg-alt) 60%, transparent);
+}
+
+.review-card-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 10px 12px;
+  background: none;
+  border: none;
+  text-align: left;
+  color: inherit;
+}
+
+.review-card-head-static {
+  cursor: default;
+  flex-wrap: wrap;
+}
+
+.review-card-time {
+  font-family: var(--font-heading);
+  font-variant-numeric: tabular-nums;
+  font-size: 0.82rem;
+  color: var(--muted);
+  min-width: 56px;
+}
+
+.review-card-notes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  flex: 1;
+}
+
+.review-note-chip-static {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  font-size: 0.92rem;
+}
+
+.review-note-chip-static small {
+  color: var(--muted);
+  font-size: 0.7rem;
+}
+
+.review-note-chip-static.ghost {
+  background: rgba(176, 141, 62, 0.14);
+  border: 1px dashed rgba(176, 141, 62, 0.5);
+}
+
+.review-origin-badge {
+  font-size: 0.68rem;
+  padding: 2px 7px;
+  border-radius: 999px;
+  white-space: nowrap;
+  background: rgba(30, 31, 31, 0.06);
+  color: var(--muted);
+}
+
+.review-origin-badge.origin-edited,
+.review-origin-badge.origin-inserted-slot,
+.review-origin-badge.origin-inserted-manual {
+  background: rgba(176, 141, 62, 0.18);
+  color: #7a5e1f;
+}
+
+.review-slot-meta {
+  font-size: 0.72rem;
+  color: var(--muted);
+}
+
+.review-card-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 0 12px 12px;
+  border-top: 1px dashed var(--line);
+  padding-top: 10px;
+}
+
+.review-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.review-note-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 6px 4px 12px;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  font-size: 0.95rem;
+}
+
+.review-note-chip small {
+  color: var(--muted);
+  font-size: 0.72rem;
+}
+
+.review-chip-x {
+  border: none;
+  background: rgba(30, 31, 31, 0.08);
+  border-radius: 999px;
+  width: 22px;
+  height: 22px;
+  line-height: 1;
+  font-size: 0.85rem;
+  color: var(--ink);
+}
+
+.review-chip-x:hover {
+  background: var(--danger);
+  color: #fff;
+}
+
+.review-note-add {
+  border: 1px dashed var(--line);
+  border-radius: 999px;
+  background: transparent;
+  padding: 5px 10px;
+  font-size: 0.85rem;
+  color: var(--muted);
+  max-width: 100%;
+}
+
+.review-suggestions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.review-suggestions-label {
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.review-suggestion-chip {
+  border: 1px solid rgba(176, 141, 62, 0.55);
+  background: rgba(176, 141, 62, 0.1);
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 0.85rem;
+}
+
+.review-suggestion-chip small {
+  color: var(--muted);
+}
+
+.review-suggestion-chip:hover {
+  background: rgba(176, 141, 62, 0.22);
+}
+
+.review-card-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.review-btn {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--bg-alt);
+  padding: 9px 14px;
+  font-size: 0.9rem;
+}
+
+.review-btn:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.review-btn-small {
+  padding: 6px 11px;
+  font-size: 0.82rem;
+}
+
+.review-btn-primary {
+  background: var(--accent);
+  border-color: var(--accent-strong);
+  color: #fff;
+}
+
+.review-btn-primary:not(:disabled):hover {
+  background: var(--accent-strong);
+}
+
+.review-btn-danger {
+  color: var(--danger);
+  border-color: rgba(166, 61, 64, 0.4);
+}
+
+.review-btn-danger:hover {
+  background: rgba(166, 61, 64, 0.08);
+}
+
+.review-footer {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 6;
+  background: color-mix(in srgb, var(--bg-alt) 92%, transparent);
+  backdrop-filter: blur(8px);
+  border-top: 1px solid var(--line);
+  padding: 10px 16px calc(10px + env(safe-area-inset-bottom));
+}
+
+.review-footer-actions {
+  display: flex;
+  gap: 10px;
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.review-footer-actions .review-btn-primary {
+  margin-left: auto;
+}
+
+.review-save-status {
+  max-width: 720px;
+  margin: 4px auto 0;
+  font-size: 0.75rem;
+  min-height: 1em;
+}
+
+.score-viewer-review-link-row {
+  display: flex;
+}
+
+.score-viewer-review-link {
+  display: inline-block;
+  padding: 10px 16px;
+  border: 1px solid var(--accent-strong);
+  border-radius: 10px;
+  color: var(--accent-strong);
+  text-decoration: none;
+  font-size: 0.95rem;
+}
+
+.score-viewer-review-link:hover {
+  background: var(--accent-soft);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .review-card {
+    transition: none;
+  }
+}

--- a/apps/web/src/app/score/[transactionId]/review/page.tsx
+++ b/apps/web/src/app/score/[transactionId]/review/page.tsx
@@ -1,0 +1,10 @@
+import { ReviewEditor } from "@/components/ReviewEditor";
+
+export default async function ScoreReviewPage({
+  params,
+}: {
+  params: Promise<{ transactionId: string }>;
+}) {
+  const { transactionId } = await params;
+  return <ReviewEditor transactionId={transactionId} />;
+}

--- a/apps/web/src/components/ReviewEditor.tsx
+++ b/apps/web/src/components/ReviewEditor.tsx
@@ -114,7 +114,10 @@ export function ReviewEditor({ transactionId }: { transactionId: string }) {
   }
 
   return (
+    // key で transaction ごとにコンポーネントを作り直す。client-side 遷移で
+    // 前の transaction の編集 state が持ち越され、別 transaction に保存される事故を防ぐ
     <ReviewEditorReady
+      key={transactionId}
       transactionId={transactionId}
       result={state.result}
       audioUrl={state.audioUrl}
@@ -153,6 +156,7 @@ function ReviewEditorReady({ transactionId, result, audioUrl, initialCorrections
 
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const stopAtRef = useRef<number | null>(null);
+  const programmaticSeekRef = useRef(false);
 
   const knownNotes = useMemo(() => buildKnownNoteIndex(result), [result]);
   const sourceEventById = useMemo(
@@ -224,6 +228,9 @@ function ReviewEditorReady({ transactionId, result, audioUrl, initialCorrections
       const followers = visibleEvents.filter((e) => e.timeSec > event.timeSec + 0.01);
       const nextStart = followers.length > 0 ? followers[0].timeSec : event.timeSec + AUDITION_MAX_SEC;
       stopAtRef.current = Math.min(nextStart, event.timeSec + AUDITION_MAX_SEC);
+      // この currentTime 代入も onSeeking を発火させるため、programmatic seek を
+      // マークして stopAt の解除対象から除外する (ユーザー操作の seek のみ解除)
+      programmaticSeekRef.current = true;
       audio.currentTime = Math.max(0, event.timeSec - AUDITION_LEAD_SEC);
       void audio.play();
     },
@@ -321,6 +328,12 @@ function ReviewEditorReady({ transactionId, result, audioUrl, initialCorrections
           controls
           onTimeUpdate={handleTimeUpdate}
           onSeeking={() => {
+            // auditionEvent 由来の programmatic seek では stopAt を維持し、
+            // ユーザーが自分でシークした時だけ区間再生を解除する
+            if (programmaticSeekRef.current) {
+              programmaticSeekRef.current = false;
+              return;
+            }
             stopAtRef.current = null;
           }}
           className="review-audio"
@@ -388,10 +401,15 @@ function ReviewEditorReady({ transactionId, result, audioUrl, initialCorrections
           </button>
         </div>
         <p className="review-save-status muted" role="status">
-          {saveState === "saved" && !dirty && "保存しました"}
-          {saveState === "error" && "保存できませんでした"}
-          {dirty && saveState !== "saving" && "未保存の修正があります"}
-          {!dirty && saveState === "idle" && " "}
+          {saveState === "error"
+            ? "保存できませんでした — 未保存の修正があります"
+            : saveState === "saving"
+            ? "保存中…"
+            : dirty
+            ? "未保存の修正があります"
+            : saveState === "saved"
+            ? "保存しました"
+            : "\u00a0"}
         </p>
       </footer>
     </main>

--- a/apps/web/src/components/ReviewEditor.tsx
+++ b/apps/web/src/components/ReviewEditor.tsx
@@ -295,7 +295,16 @@ function ReviewEditorReady({ transactionId, result, audioUrl, initialCorrections
     <main className="review-shell">
       <header className="review-header">
         <div className="review-header-row">
-          <Link href={`/score/${transactionId}`} className="review-back-link">
+          <Link
+            href={`/score/${transactionId}`}
+            className="review-back-link"
+            onClick={(e) => {
+              // beforeunload はアプリ内 route 遷移には効かないため、ここでも守る
+              if (dirty && !window.confirm("未保存の修正があります。保存せずに移動しますか?")) {
+                e.preventDefault();
+              }
+            }}
+          >
             ← 譜面へ戻る
           </Link>
           <h1 className="review-title">確認と修正</h1>

--- a/apps/web/src/components/ReviewEditor.tsx
+++ b/apps/web/src/components/ReviewEditor.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/lib/api";
 import {
   activeEvents,
+  hasActiveEventAt,
   addNote,
   buildInitialState,
   buildKnownNoteIndex,
@@ -69,10 +70,13 @@ export function ReviewEditor({ transactionId }: { transactionId: string }) {
 
     async function load() {
       try {
+        // fetchCorrections の失敗を握りつぶさない: 保存済み修正が見えないまま
+        // baseline で開くと、次の保存で既存修正を上書きしてしまう。
+        // 失敗時はページ全体をエラー表示にする (404 は api.ts 側で null になる)。
         const [result, audioBlob, corrections] = await Promise.all([
           fetchTranscription(transactionId),
           fetchTranscriptionAudioBlob(transactionId),
-          fetchCorrections(transactionId).catch(() => null),
+          fetchCorrections(transactionId),
         ]);
         if (cancelled) return;
         objectUrl = URL.createObjectURL(audioBlob);
@@ -138,7 +142,6 @@ function ReviewEditorReady({ transactionId, result, audioUrl, initialCorrections
   );
   const [history, setHistory] = useState<ReviewState[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [insertedSlotKeys, setInsertedSlotKeys] = useState<Set<number>>(new Set());
   const [saveState, setSaveState] = useState<"idle" | "saving" | "saved" | "error">("idle");
   const lastSavedRef = useRef<string>(
     JSON.stringify(
@@ -180,7 +183,6 @@ function ReviewEditorReady({ transactionId, result, audioUrl, initialCorrections
 
   const resetAll = useCallback(() => {
     apply(() => buildInitialState(result));
-    setInsertedSlotKeys(new Set());
   }, [apply, result]);
 
   const payload = useMemo(() => toCorrectionsPayload(reviewState), [reviewState]);
@@ -195,6 +197,8 @@ function ReviewEditorReady({ transactionId, result, audioUrl, initialCorrections
     if (!dirty) return;
     const handler = (event: BeforeUnloadEvent) => {
       event.preventDefault();
+      // returnValue をセットしないと確認ダイアログを出さないブラウザがある
+      event.returnValue = "";
     };
     window.addEventListener("beforeunload", handler);
     return () => window.removeEventListener("beforeunload", handler);
@@ -245,9 +249,8 @@ function ReviewEditorReady({ transactionId, result, audioUrl, initialCorrections
   );
 
   const handleInsertSlot = useCallback(
-    (slot: CandidateSlot, slotIndex: number) => {
+    (slot: CandidateSlot) => {
       apply((state) => insertEvent(state, slot.startTime, [slot.primaryNote], "inserted-slot"));
-      setInsertedSlotKeys((keys) => new Set(keys).add(slotIndex));
     },
     [apply],
   );
@@ -268,11 +271,14 @@ function ReviewEditorReady({ transactionId, result, audioUrl, initialCorrections
       event,
     }));
     (result.candidateSlots ?? []).forEach((slot, slotIndex) => {
-      if (insertedSlotKeys.has(slotIndex)) return;
+      // 同時刻にアクティブなイベントがある slot は表示しない。挿入記録ではなく
+      // state で判定することで、保存済み corrections から復元された
+      // inserted-slot イベントとの重複表示 (=重複挿入) を防ぐ
+      if (hasActiveEventAt(reviewState, slot.startTime)) return;
       items.push({ kind: "slot", timeSec: slot.startTime, slot, slotIndex });
     });
     return items.sort((a, b) => a.timeSec - b.timeSec);
-  }, [reviewState.events, result.candidateSlots, insertedSlotKeys]);
+  }, [reviewState, result.candidateSlots]);
 
   const displayEvents = useMemo(() => toDisplayScoreEvents(reviewState), [reviewState]);
 
@@ -344,7 +350,7 @@ function ReviewEditorReady({ transactionId, result, audioUrl, initialCorrections
             <SlotCard
               key={`slot-${item.slotIndex}`}
               slot={item.slot}
-              onInsert={() => handleInsertSlot(item.slot, item.slotIndex)}
+              onInsert={() => handleInsertSlot(item.slot)}
             />
           ),
         )}

--- a/apps/web/src/components/ReviewEditor.tsx
+++ b/apps/web/src/components/ReviewEditor.tsx
@@ -1,0 +1,582 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { DoReMiScore } from "@/components/DoReMiScore";
+import {
+  fetchCorrections,
+  fetchTranscription,
+  fetchTranscriptionAudioBlob,
+  saveCorrections,
+} from "@/lib/api";
+import {
+  activeEvents,
+  addNote,
+  buildInitialState,
+  buildKnownNoteIndex,
+  insertEvent,
+  noteName,
+  removeNote,
+  resolveScoreNote,
+  restoreStateFromCorrections,
+  toCorrectionsPayload,
+  toDisplayScoreEvents,
+  toggleRemoved,
+  type ReviewEvent,
+  type ReviewState,
+} from "@/lib/reviewCorrections";
+import {
+  CandidateSlot,
+  CorrectionsPayload,
+  ReviewOrigin,
+  ScoreNote,
+  TranscriptionResult,
+} from "@/lib/types";
+
+const AUDITION_LEAD_SEC = 0.15;
+const AUDITION_MAX_SEC = 4.0;
+
+const ORIGIN_LABELS: Record<ReviewOrigin, string> = {
+  recognizer: "認識",
+  edited: "修正済",
+  "inserted-slot": "候補から追加",
+  "inserted-manual": "手動追加",
+};
+
+const DROP_REASON_LABELS: Record<string, string> = {
+  "residual-decay-no-reattack": "残響の可能性",
+  "orphan-onset-no-segment": "onset のみ検出",
+  low_register_sparse_gap_tail: "低域の弱い尾部",
+};
+
+type LoadState =
+  | { kind: "loading" }
+  | {
+      kind: "ready";
+      result: TranscriptionResult;
+      audioUrl: string;
+      corrections: CorrectionsPayload | null;
+    }
+  | { kind: "error"; message: string };
+
+export function ReviewEditor({ transactionId }: { transactionId: string }) {
+  const [state, setState] = useState<LoadState>({ kind: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    let objectUrl: string | null = null;
+
+    async function load() {
+      try {
+        const [result, audioBlob, corrections] = await Promise.all([
+          fetchTranscription(transactionId),
+          fetchTranscriptionAudioBlob(transactionId),
+          fetchCorrections(transactionId).catch(() => null),
+        ]);
+        if (cancelled) return;
+        objectUrl = URL.createObjectURL(audioBlob);
+        setState({ kind: "ready", result, audioUrl: objectUrl, corrections });
+      } catch (err) {
+        if (cancelled) return;
+        setState({
+          kind: "error",
+          message: err instanceof Error ? err.message : "読み込みに失敗しました。",
+        });
+      }
+    }
+
+    load();
+    return () => {
+      cancelled = true;
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [transactionId]);
+
+  if (state.kind === "loading") {
+    return (
+      <main className="review-shell">
+        <p className="muted">読み込み中…</p>
+      </main>
+    );
+  }
+
+  if (state.kind === "error") {
+    return (
+      <main className="review-shell">
+        <p className="empty">読み込めませんでした: {state.message}</p>
+      </main>
+    );
+  }
+
+  return (
+    <ReviewEditorReady
+      transactionId={transactionId}
+      result={state.result}
+      audioUrl={state.audioUrl}
+      initialCorrections={state.corrections}
+    />
+  );
+}
+
+type ReadyProps = {
+  transactionId: string;
+  result: TranscriptionResult;
+  audioUrl: string;
+  initialCorrections: CorrectionsPayload | null;
+};
+
+type TimelineItem =
+  | { kind: "event"; timeSec: number; event: ReviewEvent }
+  | { kind: "slot"; timeSec: number; slot: CandidateSlot; slotIndex: number };
+
+function ReviewEditorReady({ transactionId, result, audioUrl, initialCorrections }: ReadyProps) {
+  const [reviewState, setReviewState] = useState<ReviewState>(() =>
+    initialCorrections
+      ? restoreStateFromCorrections(result, initialCorrections)
+      : buildInitialState(result),
+  );
+  const [history, setHistory] = useState<ReviewState[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [insertedSlotKeys, setInsertedSlotKeys] = useState<Set<number>>(new Set());
+  const [saveState, setSaveState] = useState<"idle" | "saving" | "saved" | "error">("idle");
+  const lastSavedRef = useRef<string>(
+    JSON.stringify(
+      initialCorrections
+        ? toCorrectionsPayload(restoreStateFromCorrections(result, initialCorrections))
+        : null,
+    ),
+  );
+
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const stopAtRef = useRef<number | null>(null);
+
+  const knownNotes = useMemo(() => buildKnownNoteIndex(result), [result]);
+  const sourceEventById = useMemo(
+    () => new Map(result.events.map((event) => [event.id, event])),
+    [result.events],
+  );
+
+  const apply = useCallback(
+    (next: (state: ReviewState) => ReviewState) => {
+      setReviewState((current) => {
+        const updated = next(current);
+        if (updated === current) return current;
+        setHistory((stack) => [...stack, current]);
+        return updated;
+      });
+    },
+    [],
+  );
+
+  const undo = useCallback(() => {
+    setHistory((stack) => {
+      if (stack.length === 0) return stack;
+      const previous = stack[stack.length - 1];
+      setReviewState(previous);
+      return stack.slice(0, -1);
+    });
+  }, []);
+
+  const resetAll = useCallback(() => {
+    apply(() => buildInitialState(result));
+    setInsertedSlotKeys(new Set());
+  }, [apply, result]);
+
+  const payload = useMemo(() => toCorrectionsPayload(reviewState), [reviewState]);
+  const payloadJson = useMemo(() => JSON.stringify(payload), [payload]);
+  const initialJson = useMemo(
+    () => JSON.stringify(toCorrectionsPayload(buildInitialState(result))),
+    [result],
+  );
+  const dirty = payloadJson !== lastSavedRef.current && !(lastSavedRef.current === "null" && payloadJson === initialJson);
+
+  useEffect(() => {
+    if (!dirty) return;
+    const handler = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [dirty]);
+
+  const handleSave = useCallback(async () => {
+    setSaveState("saving");
+    try {
+      await saveCorrections(transactionId, payload);
+      lastSavedRef.current = payloadJson;
+      setSaveState("saved");
+    } catch {
+      setSaveState("error");
+    }
+  }, [transactionId, payload, payloadJson]);
+
+  const visibleEvents = useMemo(() => activeEvents(reviewState), [reviewState]);
+
+  const auditionEvent = useCallback(
+    (event: ReviewEvent) => {
+      const audio = audioRef.current;
+      if (!audio) return;
+      const followers = visibleEvents.filter((e) => e.timeSec > event.timeSec + 0.01);
+      const nextStart = followers.length > 0 ? followers[0].timeSec : event.timeSec + AUDITION_MAX_SEC;
+      stopAtRef.current = Math.min(nextStart, event.timeSec + AUDITION_MAX_SEC);
+      audio.currentTime = Math.max(0, event.timeSec - AUDITION_LEAD_SEC);
+      void audio.play();
+    },
+    [visibleEvents],
+  );
+
+  const handleTimeUpdate = useCallback(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    if (stopAtRef.current !== null && audio.currentTime >= stopAtRef.current) {
+      audio.pause();
+      stopAtRef.current = null;
+    }
+  }, []);
+
+  const handleSelect = useCallback(
+    (eventId: string) => {
+      setSelectedId(eventId);
+      const event = reviewState.events.find((e) => e.id === eventId);
+      if (event && !event.removed) auditionEvent(event);
+    },
+    [reviewState.events, auditionEvent],
+  );
+
+  const handleInsertSlot = useCallback(
+    (slot: CandidateSlot, slotIndex: number) => {
+      apply((state) => insertEvent(state, slot.startTime, [slot.primaryNote], "inserted-slot"));
+      setInsertedSlotKeys((keys) => new Set(keys).add(slotIndex));
+    },
+    [apply],
+  );
+
+  const handleInsertAtPlayhead = useCallback(
+    (note: ScoreNote) => {
+      const audio = audioRef.current;
+      const timeSec = audio ? audio.currentTime : 0;
+      apply((state) => insertEvent(state, timeSec, [note], "inserted-manual"));
+    },
+    [apply],
+  );
+
+  const timeline = useMemo<TimelineItem[]>(() => {
+    const items: TimelineItem[] = reviewState.events.map((event) => ({
+      kind: "event" as const,
+      timeSec: event.timeSec,
+      event,
+    }));
+    (result.candidateSlots ?? []).forEach((slot, slotIndex) => {
+      if (insertedSlotKeys.has(slotIndex)) return;
+      items.push({ kind: "slot", timeSec: slot.startTime, slot, slotIndex });
+    });
+    return items.sort((a, b) => a.timeSec - b.timeSec);
+  }, [reviewState.events, result.candidateSlots, insertedSlotKeys]);
+
+  const displayEvents = useMemo(() => toDisplayScoreEvents(reviewState), [reviewState]);
+
+  const pickerNotes = useMemo(() => {
+    return result.instrumentTuning.notes
+      .map((tuningNote) =>
+        resolveScoreNote(tuningNote.noteName, knownNotes, result.instrumentTuning),
+      )
+      .filter((note): note is ScoreNote => note !== null)
+      .sort((a, b) => a.frequency - b.frequency);
+  }, [result.instrumentTuning, knownNotes]);
+
+  return (
+    <main className="review-shell">
+      <header className="review-header">
+        <div className="review-header-row">
+          <Link href={`/score/${transactionId}`} className="review-back-link">
+            ← 譜面へ戻る
+          </Link>
+          <h1 className="review-title">確認と修正</h1>
+        </div>
+        <p className="review-subtitle muted">
+          イベントを選ぶとその部分を再生します。音の過不足はカードから直せます。
+        </p>
+      </header>
+
+      <section className="review-playback">
+        <audio
+          ref={audioRef}
+          src={audioUrl}
+          controls
+          onTimeUpdate={handleTimeUpdate}
+          onSeeking={() => {
+            stopAtRef.current = null;
+          }}
+          className="review-audio"
+        />
+        <InsertAtPlayheadControl notes={pickerNotes} onInsert={handleInsertAtPlayhead} />
+      </section>
+
+      <section className="review-score">
+        <DoReMiScore
+          events={displayEvents}
+          activeEventId={selectedId}
+          onActiveEventIdChange={handleSelect}
+        />
+      </section>
+
+      <section className="review-timeline" aria-label="イベント一覧">
+        {timeline.map((item) =>
+          item.kind === "event" ? (
+            <EventCard
+              key={item.event.id}
+              event={item.event}
+              selected={selectedId === item.event.id}
+              suggestions={
+                item.event.sourceEventId
+                  ? sourceEventById.get(item.event.sourceEventId)?.alternateGroupings ?? null
+                  : null
+              }
+              pickerNotes={pickerNotes}
+              onSelect={() => handleSelect(item.event.id)}
+              onAudition={() => auditionEvent(item.event)}
+              onRemoveNote={(name) => apply((s) => removeNote(s, item.event.id, name))}
+              onAddNote={(note) => apply((s) => addNote(s, item.event.id, note))}
+              onToggleRemoved={() => apply((s) => toggleRemoved(s, item.event.id))}
+            />
+          ) : (
+            <SlotCard
+              key={`slot-${item.slotIndex}`}
+              slot={item.slot}
+              onInsert={() => handleInsertSlot(item.slot, item.slotIndex)}
+            />
+          ),
+        )}
+      </section>
+
+      <footer className="review-footer">
+        <div className="review-footer-actions">
+          <button
+            type="button"
+            className="review-btn"
+            onClick={undo}
+            disabled={history.length === 0}
+          >
+            元に戻す
+          </button>
+          <button type="button" className="review-btn" onClick={resetAll}>
+            認識結果にリセット
+          </button>
+          <button
+            type="button"
+            className="review-btn review-btn-primary"
+            onClick={handleSave}
+            disabled={saveState === "saving" || !dirty}
+          >
+            {saveState === "saving" ? "保存中…" : "修正を保存"}
+          </button>
+        </div>
+        <p className="review-save-status muted" role="status">
+          {saveState === "saved" && !dirty && "保存しました"}
+          {saveState === "error" && "保存できませんでした"}
+          {dirty && saveState !== "saving" && "未保存の修正があります"}
+          {!dirty && saveState === "idle" && " "}
+        </p>
+      </footer>
+    </main>
+  );
+}
+
+function formatTime(sec: number): string {
+  return `${sec.toFixed(2)}s`;
+}
+
+function EventCard({
+  event,
+  selected,
+  suggestions,
+  pickerNotes,
+  onSelect,
+  onAudition,
+  onRemoveNote,
+  onAddNote,
+  onToggleRemoved,
+}: {
+  event: ReviewEvent;
+  selected: boolean;
+  suggestions: TranscriptionResult["events"][number]["alternateGroupings"];
+  pickerNotes: ScoreNote[];
+  onSelect: () => void;
+  onAudition: () => void;
+  onRemoveNote: (name: string) => void;
+  onAddNote: (note: ScoreNote) => void;
+  onToggleRemoved: () => void;
+}) {
+  const noteSuggestions = (suggestions ?? [])
+    .filter((alt) => alt.alternateNote !== null)
+    .filter(
+      (alt) => !event.notes.some((n) => noteName(n) === noteName(alt.alternateNote as ScoreNote)),
+    );
+
+  const addableNotes = pickerNotes.filter(
+    (note) => !event.notes.some((existing) => noteName(existing) === noteName(note)),
+  );
+
+  const classNames = [
+    "review-card",
+    `review-card-${event.origin}`,
+    selected ? "selected" : "",
+    event.removed ? "removed" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <article className={classNames}>
+      <button type="button" className="review-card-head" onClick={onSelect}>
+        <span className="review-card-time">{formatTime(event.timeSec)}</span>
+        <span className="review-card-notes">
+          {event.notes.map((note) => (
+            <span key={noteName(note)} className="review-note-chip-static">
+              {note.labelDoReMi}
+              <small>{noteName(note)}</small>
+            </span>
+          ))}
+        </span>
+        <span className={`review-origin-badge origin-${event.origin}`}>
+          {event.removed ? "削除済" : ORIGIN_LABELS[event.origin]}
+        </span>
+      </button>
+
+      {selected && !event.removed ? (
+        <div className="review-card-editor">
+          <div className="review-chip-row">
+            {event.notes.map((note) => (
+              <span key={noteName(note)} className="review-note-chip">
+                {note.labelDoReMi} <small>{noteName(note)}</small>
+                {event.notes.length > 1 ? (
+                  <button
+                    type="button"
+                    className="review-chip-x"
+                    aria-label={`${noteName(note)} を外す`}
+                    onClick={() => onRemoveNote(noteName(note))}
+                  >
+                    ×
+                  </button>
+                ) : null}
+              </span>
+            ))}
+            {addableNotes.length > 0 ? (
+              <select
+                className="review-note-add"
+                value=""
+                aria-label="音を追加"
+                onChange={(e) => {
+                  const note = addableNotes.find((n) => noteName(n) === e.target.value);
+                  if (note) onAddNote(note);
+                }}
+              >
+                <option value="">＋ 音を追加</option>
+                {addableNotes.map((note) => (
+                  <option key={noteName(note)} value={noteName(note)}>
+                    {note.labelDoReMi} ({noteName(note)})
+                  </option>
+                ))}
+              </select>
+            ) : null}
+          </div>
+
+          {noteSuggestions.length > 0 ? (
+            <div className="review-suggestions">
+              <span className="review-suggestions-label">認識器の次候補:</span>
+              {noteSuggestions.map((alt) => {
+                const note = alt.alternateNote as ScoreNote;
+                return (
+                  <button
+                    key={noteName(note)}
+                    type="button"
+                    className="review-suggestion-chip"
+                    onClick={() => onAddNote(note)}
+                  >
+                    ＋{note.labelDoReMi} <small>{Math.round(alt.confidence * 100)}%</small>
+                  </button>
+                );
+              })}
+            </div>
+          ) : null}
+
+          <div className="review-card-actions">
+            <button type="button" className="review-btn review-btn-small" onClick={onAudition}>
+              ▶ この部分を再生
+            </button>
+            <button
+              type="button"
+              className="review-btn review-btn-small review-btn-danger"
+              onClick={onToggleRemoved}
+            >
+              このイベントを削除
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      {selected && event.removed ? (
+        <div className="review-card-editor">
+          <div className="review-card-actions">
+            <button type="button" className="review-btn review-btn-small" onClick={onToggleRemoved}>
+              復元する
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </article>
+  );
+}
+
+function SlotCard({ slot, onInsert }: { slot: CandidateSlot; onInsert: () => void }) {
+  const reasonLabel = DROP_REASON_LABELS[slot.dropReason] ?? slot.dropReason;
+  return (
+    <article className="review-card review-card-slot">
+      <div className="review-card-head review-card-head-static">
+        <span className="review-card-time">{formatTime(slot.startTime)}</span>
+        <span className="review-card-notes">
+          <span className="review-note-chip-static ghost">
+            {slot.primaryNote.labelDoReMi}
+            <small>{noteName(slot.primaryNote)}?</small>
+          </span>
+        </span>
+        <span className="review-slot-meta">
+          {reasonLabel} · {Math.round(slot.confidence * 100)}%
+        </span>
+        <button type="button" className="review-btn review-btn-small" onClick={onInsert}>
+          ＋ 追加
+        </button>
+      </div>
+    </article>
+  );
+}
+
+function InsertAtPlayheadControl({
+  notes,
+  onInsert,
+}: {
+  notes: ScoreNote[];
+  onInsert: (note: ScoreNote) => void;
+}) {
+  return (
+    <div className="review-insert-control">
+      <select
+        className="review-note-add"
+        value=""
+        aria-label="再生位置に音を挿入"
+        onChange={(e) => {
+          const note = notes.find((n) => noteName(n) === e.target.value);
+          if (note) onInsert(note);
+        }}
+      >
+        <option value="">＋ 再生位置に音を挿入…</option>
+        {notes.map((note) => (
+          <option key={noteName(note)} value={noteName(note)}>
+            {note.labelDoReMi} ({noteName(note)})
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/apps/web/src/components/ScoreViewer.tsx
+++ b/apps/web/src/components/ScoreViewer.tsx
@@ -238,6 +238,12 @@ function ScoreViewerReady({ transactionId, result, audioUrl, initialMemo }: Read
         />
       </section>
 
+      <section className="score-viewer-review-link-row">
+        <Link href={`/score/${transactionId}/review`} className="score-viewer-review-link">
+          結果を確認・修正する →
+        </Link>
+      </section>
+
       <RetranscribeSection
         transactionId={transactionId}
         currentTuningId={result.instrumentTuning.id}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import { InstrumentTuning, TranscriptionResult } from "@/lib/types";
+import { CorrectionsPayload, InstrumentTuning, TranscriptionResult } from "@/lib/types";
 import { WavMetadata, toWavWithMetadata } from "@/lib/audio";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "";
@@ -234,6 +234,33 @@ export async function saveMemo(transactionId: string, memo: string): Promise<voi
   if (!response.ok) {
     throw new Error("Failed to save memo.");
   }
+}
+
+export async function fetchCorrections(transactionId: string): Promise<CorrectionsPayload | null> {
+  const response = await fetch(`${API_BASE_URL}/api/transcriptions/${transactionId}/corrections`, {
+    cache: "no-store",
+  });
+  if (!response.ok) {
+    throw new Error("Failed to load corrections.");
+  }
+  const payload = (await response.json()) as { corrections: CorrectionsPayload | null };
+  return payload.corrections;
+}
+
+export async function saveCorrections(
+  transactionId: string,
+  corrections: CorrectionsPayload,
+): Promise<CorrectionsPayload> {
+  const response = await fetch(`${API_BASE_URL}/api/transcriptions/${transactionId}/corrections`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(corrections),
+  });
+  if (!response.ok) {
+    throw new Error("Failed to save corrections.");
+  }
+  const payload = (await response.json()) as { corrections: CorrectionsPayload };
+  return payload.corrections;
 }
 
 function cleanOptionalText(value: string | undefined): string | null {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -240,6 +240,10 @@ export async function fetchCorrections(transactionId: string): Promise<Correctio
   const response = await fetch(`${API_BASE_URL}/api/transcriptions/${transactionId}/corrections`, {
     cache: "no-store",
   });
+  // 404 = 修正が存在しない (transaction なし / 旧 API)。それ以外の失敗は
+  // 「保存済み修正があるのに見えていない」可能性があるため throw する
+  // (黙って認識 baseline に戻すと、次の保存で既存修正を上書きしてしまう)。
+  if (response.status === 404) return null;
   if (!response.ok) {
     throw new Error("Failed to load corrections.");
   }

--- a/apps/web/src/lib/reviewCorrections.test.ts
+++ b/apps/web/src/lib/reviewCorrections.test.ts
@@ -38,6 +38,7 @@ function makeResult(): TranscriptionResult {
       name: "17 Key C Major",
       keyCount: 17,
       notes: [
+        { key: 6, noteName: "Bb4", frequency: 466.164 },
         { key: 7, noteName: "F4", frequency: 349.228 },
         { key: 8, noteName: "D4", frequency: 293.665 },
         { key: 9, noteName: "C4", frequency: 261.626 },
@@ -193,6 +194,15 @@ describe("resolveScoreNote", () => {
     expect(c4?.pitchClass).toBe("C");
     expect(c4?.labelDoReMi).toBe("ド");
     expect(c4?.frequency).toBeCloseTo(261.626);
+  });
+
+  it("resolves flat note names from the tuning (e.g. Bb major)", () => {
+    const result = makeResult();
+    const index = buildKnownNoteIndex(result);
+    const bb4 = resolveScoreNote("Bb4", index, result.instrumentTuning);
+    expect(bb4?.pitchClass).toBe("Bb");
+    expect(bb4?.labelDoReMi).toBe("シb");
+    expect(bb4?.frequency).toBeCloseTo(466.164);
   });
 
   it("returns null for notes outside the tuning", () => {

--- a/apps/web/src/lib/reviewCorrections.test.ts
+++ b/apps/web/src/lib/reviewCorrections.test.ts
@@ -4,6 +4,7 @@ import {
   activeEvents,
   addNote,
   buildInitialState,
+  hasActiveEventAt,
   insertEvent,
   removeNote,
   resolveScoreNote,
@@ -148,6 +149,33 @@ describe("payload roundtrip", () => {
     expect(removed?.removed).toBe(true);
 
     expect(toCorrectionsPayload(state)).toEqual(corrections);
+  });
+});
+
+describe("hasActiveEventAt (candidateSlot 表示抑制)", () => {
+  it("detects events inserted from a slot in the current session", () => {
+    const state = insertEvent(buildInitialState(makeResult()), 5.5, [F4], "inserted-slot");
+    expect(hasActiveEventAt(state, 5.5)).toBe(true);
+    expect(hasActiveEventAt(state, 6.5)).toBe(false);
+  });
+
+  it("detects inserted-slot events restored from saved corrections", () => {
+    const result = makeResult();
+    const state = restoreStateFromCorrections(result, {
+      version: 1,
+      events: [
+        { timeSec: 4.445, notes: ["D4", "D5"], origin: "recognizer" },
+        { timeSec: 7.069, notes: ["D4", "D5"], origin: "recognizer" },
+        { timeSec: 5.5, notes: ["F4"], origin: "inserted-slot" },
+      ],
+    });
+    // 復元された inserted-slot イベントの時刻では slot を再表示しない
+    expect(hasActiveEventAt(state, 5.5)).toBe(true);
+  });
+
+  it("ignores removed events", () => {
+    const state = toggleRemoved(buildInitialState(makeResult()), "evt-1");
+    expect(hasActiveEventAt(state, 4.445)).toBe(false);
   });
 });
 

--- a/apps/web/src/lib/reviewCorrections.test.ts
+++ b/apps/web/src/lib/reviewCorrections.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  activeEvents,
+  addNote,
+  buildInitialState,
+  insertEvent,
+  removeNote,
+  resolveScoreNote,
+  restoreStateFromCorrections,
+  buildKnownNoteIndex,
+  toCorrectionsPayload,
+  toggleRemoved,
+} from "@/lib/reviewCorrections";
+import { CorrectionsPayload, ScoreNote, TranscriptionResult } from "@/lib/types";
+
+function note(pitchClass: string, octave: number, frequency: number, key = 1): ScoreNote {
+  return {
+    key,
+    pitchClass,
+    octave,
+    labelDoReMi: pitchClass,
+    labelNumber: "1",
+    frequency,
+  };
+}
+
+const D4 = note("D", 4, 293.665, 8);
+const D5 = note("D", 5, 587.33, 13);
+const F4 = note("F", 4, 349.228, 7);
+
+function makeResult(): TranscriptionResult {
+  return {
+    transactionId: "tx-1",
+    instrumentTuning: {
+      id: "kalimba-17-c",
+      name: "17 Key C Major",
+      keyCount: 17,
+      notes: [
+        { key: 7, noteName: "F4", frequency: 349.228 },
+        { key: 8, noteName: "D4", frequency: 293.665 },
+        { key: 9, noteName: "C4", frequency: 261.626 },
+        { key: 13, noteName: "D5", frequency: 587.33 },
+      ],
+    },
+    tempo: 120,
+    events: [
+      {
+        id: "evt-1",
+        startBeat: 0,
+        durationBeat: 1,
+        startTimeSec: 4.445,
+        notes: [D4, D5],
+        isGlissLike: false,
+        gesture: "ambiguous",
+        alternateGroupings: [
+          {
+            combinesWith: null,
+            combinedNotes: null,
+            splitInto: null,
+            alternateNote: F4,
+            reason: "soft_rejected:score-below-threshold",
+            confidence: 0.7,
+          },
+        ],
+      },
+      {
+        id: "evt-2",
+        startBeat: 1,
+        durationBeat: 1,
+        startTimeSec: 7.069,
+        notes: [D4, D5],
+        isGlissLike: false,
+        gesture: "ambiguous",
+      },
+    ],
+    candidateSlots: [],
+    notationViews: { western: [], numbered: [], verticalDoReMi: [] },
+    warnings: [],
+  };
+}
+
+describe("buildInitialState", () => {
+  it("maps recognizer events with origin recognizer", () => {
+    const state = buildInitialState(makeResult());
+    expect(state.events).toHaveLength(2);
+    expect(state.events[0].origin).toBe("recognizer");
+    expect(state.events[0].sourceEventId).toBe("evt-1");
+  });
+});
+
+describe("note editing", () => {
+  it("addNote sorts by frequency and marks edited", () => {
+    const state = addNote(buildInitialState(makeResult()), "evt-1", F4);
+    const event = state.events[0];
+    expect(event.notes.map((n) => `${n.pitchClass}${n.octave}`)).toEqual(["D4", "F4", "D5"]);
+    expect(event.origin).toBe("edited");
+  });
+
+  it("addNote is a no-op for duplicate notes", () => {
+    const state = addNote(buildInitialState(makeResult()), "evt-1", D4);
+    expect(state.events[0].notes).toHaveLength(2);
+    expect(state.events[0].origin).toBe("recognizer");
+  });
+
+  it("removeNote keeps at least one note", () => {
+    let state = removeNote(buildInitialState(makeResult()), "evt-1", "D5");
+    expect(state.events[0].notes.map((n) => n.pitchClass)).toEqual(["D"]);
+    expect(state.events[0].origin).toBe("edited");
+    state = removeNote(state, "evt-1", "D4");
+    expect(state.events[0].notes).toHaveLength(1);
+  });
+});
+
+describe("event-level operations", () => {
+  it("toggleRemoved flips removal and excludes from payload", () => {
+    const state = toggleRemoved(buildInitialState(makeResult()), "evt-1");
+    expect(activeEvents(state)).toHaveLength(1);
+    const payload = toCorrectionsPayload(state);
+    expect(payload.events).toHaveLength(1);
+    expect(payload.events[0].timeSec).toBeCloseTo(7.069);
+  });
+
+  it("insertEvent keeps time order and assigns ins- ids", () => {
+    const state = insertEvent(buildInitialState(makeResult()), 5.5, [F4], "inserted-manual");
+    const ids = state.events.map((e) => e.id);
+    expect(ids).toEqual(["evt-1", "ins-1", "evt-2"]);
+  });
+});
+
+describe("payload roundtrip", () => {
+  it("restoreStateFromCorrections reconciles edits, removals, insertions", () => {
+    const result = makeResult();
+    const corrections: CorrectionsPayload = {
+      version: 1,
+      events: [
+        { timeSec: 4.445, notes: ["D4", "F4", "D5"], origin: "edited" },
+        { timeSec: 5.5, notes: ["F4"], origin: "inserted-manual" },
+      ],
+    };
+    const state = restoreStateFromCorrections(result, corrections);
+    const active = activeEvents(state);
+    expect(active).toHaveLength(2);
+    expect(active[0].notes.map((n) => `${n.pitchClass}${n.octave}`)).toEqual(["D4", "F4", "D5"]);
+    expect(active[0].origin).toBe("edited");
+    expect(active[1].id).toBe("ins-1");
+    const removed = state.events.find((e) => e.id === "evt-2");
+    expect(removed?.removed).toBe(true);
+
+    expect(toCorrectionsPayload(state)).toEqual(corrections);
+  });
+});
+
+describe("resolveScoreNote", () => {
+  it("prefers known notes from the result", () => {
+    const result = makeResult();
+    const index = buildKnownNoteIndex(result);
+    expect(resolveScoreNote("F4", index, result.instrumentTuning)).toBe(F4);
+  });
+
+  it("falls back to tuning definition for unseen notes", () => {
+    const result = makeResult();
+    const index = buildKnownNoteIndex(result);
+    const c4 = resolveScoreNote("C4", index, result.instrumentTuning);
+    expect(c4?.pitchClass).toBe("C");
+    expect(c4?.labelDoReMi).toBe("ド");
+    expect(c4?.frequency).toBeCloseTo(261.626);
+  });
+
+  it("returns null for notes outside the tuning", () => {
+    const result = makeResult();
+    const index = buildKnownNoteIndex(result);
+    expect(resolveScoreNote("G9", index, result.instrumentTuning)).toBeNull();
+  });
+});

--- a/apps/web/src/lib/reviewCorrections.ts
+++ b/apps/web/src/lib/reviewCorrections.ts
@@ -253,6 +253,21 @@ export function activeEvents(state: ReviewState): ReviewEvent[] {
   return state.events.filter((event) => !event.removed);
 }
 
+/**
+ * timeSec にアクティブなイベントが存在するか。candidateSlot の表示抑制に使う
+ * (保存済み corrections から復元された inserted-slot イベントも含めて判定するため、
+ * セッションローカルな挿入記録ではなく state 自体を見る)。
+ */
+export function hasActiveEventAt(
+  state: ReviewState,
+  timeSec: number,
+  toleranceSec = TIME_MATCH_TOLERANCE_SEC,
+): boolean {
+  return state.events.some(
+    (event) => !event.removed && Math.abs(event.timeSec - timeSec) <= toleranceSec,
+  );
+}
+
 export function toCorrectionsPayload(state: ReviewState): CorrectionsPayload {
   return {
     version: 1,

--- a/apps/web/src/lib/reviewCorrections.ts
+++ b/apps/web/src/lib/reviewCorrections.ts
@@ -1,0 +1,278 @@
+import {
+  CorrectionsPayload,
+  InstrumentTuning,
+  ReviewOrigin,
+  ScoreEvent,
+  ScoreNote,
+  TranscriptionResult,
+} from "@/lib/types";
+
+export type ReviewEvent = {
+  id: string;
+  timeSec: number;
+  notes: ScoreNote[];
+  origin: ReviewOrigin;
+  removed: boolean;
+  /** recognizer 出力由来の場合は元 event id (alternateGroupings 参照用) */
+  sourceEventId: string | null;
+};
+
+export type ReviewState = {
+  events: ReviewEvent[];
+  nextInsertId: number;
+};
+
+const TIME_MATCH_TOLERANCE_SEC = 0.005;
+
+const DOREMI_BY_PITCH_CLASS: Record<string, string> = {
+  C: "ド",
+  "C#": "ド#",
+  D: "レ",
+  "D#": "レ#",
+  E: "ミ",
+  F: "ファ",
+  "F#": "ファ#",
+  G: "ソ",
+  "G#": "ソ#",
+  A: "ラ",
+  "A#": "ラ#",
+  B: "シ",
+};
+
+function sortNotes(notes: ScoreNote[]): ScoreNote[] {
+  return [...notes].sort((a, b) => a.frequency - b.frequency);
+}
+
+function sortEvents(events: ReviewEvent[]): ReviewEvent[] {
+  return [...events].sort((a, b) => a.timeSec - b.timeSec);
+}
+
+/** result 内に登場する全 ScoreNote (events / alternates / candidateSlots) を noteName で索引化する。 */
+export function buildKnownNoteIndex(result: TranscriptionResult): Map<string, ScoreNote> {
+  const index = new Map<string, ScoreNote>();
+  const register = (note: ScoreNote | null | undefined) => {
+    if (!note) return;
+    const name = `${note.pitchClass}${note.octave}`;
+    if (!index.has(name)) index.set(name, note);
+  };
+  for (const event of result.events) {
+    event.notes.forEach(register);
+    for (const alt of event.alternateGroupings ?? []) {
+      register(alt.alternateNote);
+      alt.combinedNotes?.forEach(register);
+      alt.splitInto?.forEach((group) => group.forEach(register));
+    }
+  }
+  for (const slot of result.candidateSlots ?? []) {
+    register(slot.primaryNote);
+    slot.candidates.forEach(register);
+  }
+  return index;
+}
+
+export function noteName(note: ScoreNote): string {
+  return `${note.pitchClass}${note.octave}`;
+}
+
+/**
+ * noteName から ScoreNote を解決する。result 内に既出ならそれを使い、
+ * 未出の音は tuning 定義から構築する (labelNumber はサーバー定義が
+ * tuning スケール依存のため、未出音では空にする — review UI は固定ド表示)。
+ */
+export function resolveScoreNote(
+  name: string,
+  knownNotes: Map<string, ScoreNote>,
+  tuning: InstrumentTuning,
+): ScoreNote | null {
+  const known = knownNotes.get(name);
+  if (known) return known;
+  const parsed = /^([A-G]#?)(\d)$/.exec(name);
+  if (!parsed) return null;
+  const tuningNote = tuning.notes.find((n) => n.noteName === name);
+  if (!tuningNote) return null;
+  const pitchClass = parsed[1];
+  const octave = Number(parsed[2]);
+  return {
+    key: tuningNote.key,
+    pitchClass,
+    octave,
+    labelDoReMi: DOREMI_BY_PITCH_CLASS[pitchClass] ?? pitchClass,
+    labelNumber: "",
+    frequency: tuningNote.frequency,
+  };
+}
+
+export function buildInitialState(result: TranscriptionResult): ReviewState {
+  return {
+    events: sortEvents(
+      result.events.map((event) => ({
+        id: event.id,
+        timeSec: event.startTimeSec,
+        notes: sortNotes(event.notes),
+        origin: "recognizer" as const,
+        removed: false,
+        sourceEventId: event.id,
+      })),
+    ),
+    nextInsertId: 1,
+  };
+}
+
+/**
+ * 保存済み corrections から状態を復元する。corrections は「最終形のイベント列」
+ * なので、recognizer イベントとは timeSec で突合する:
+ * - 一致した correction → その recognizer イベント枠に correction の notes を採用
+ * - 一致しなかった recognizer イベント → removed
+ * - どの recognizer イベントとも一致しない correction → 挿入イベント
+ */
+export function restoreStateFromCorrections(
+  result: TranscriptionResult,
+  corrections: CorrectionsPayload,
+): ReviewState {
+  const knownNotes = buildKnownNoteIndex(result);
+  const consumed = new Set<number>();
+  const events: ReviewEvent[] = [];
+  let nextInsertId = 1;
+
+  const matchCorrection = (timeSec: number): number | null => {
+    for (let i = 0; i < corrections.events.length; i += 1) {
+      if (consumed.has(i)) continue;
+      if (Math.abs(corrections.events[i].timeSec - timeSec) <= TIME_MATCH_TOLERANCE_SEC) {
+        return i;
+      }
+    }
+    return null;
+  };
+
+  for (const event of result.events) {
+    const matchIndex = matchCorrection(event.startTimeSec);
+    if (matchIndex === null) {
+      events.push({
+        id: event.id,
+        timeSec: event.startTimeSec,
+        notes: sortNotes(event.notes),
+        origin: "recognizer",
+        removed: true,
+        sourceEventId: event.id,
+      });
+      continue;
+    }
+    consumed.add(matchIndex);
+    const correction = corrections.events[matchIndex];
+    const notes = correction.notes
+      .map((name) => resolveScoreNote(name, knownNotes, result.instrumentTuning))
+      .filter((note): note is ScoreNote => note !== null);
+    events.push({
+      id: event.id,
+      timeSec: event.startTimeSec,
+      notes: sortNotes(notes.length > 0 ? notes : event.notes),
+      origin: correction.origin ?? "recognizer",
+      removed: false,
+      sourceEventId: event.id,
+    });
+  }
+
+  corrections.events.forEach((correction, index) => {
+    if (consumed.has(index)) return;
+    const notes = correction.notes
+      .map((name) => resolveScoreNote(name, knownNotes, result.instrumentTuning))
+      .filter((note): note is ScoreNote => note !== null);
+    if (notes.length === 0) return;
+    events.push({
+      id: `ins-${nextInsertId}`,
+      timeSec: correction.timeSec,
+      notes: sortNotes(notes),
+      origin: correction.origin ?? "inserted-manual",
+      removed: false,
+      sourceEventId: null,
+    });
+    nextInsertId += 1;
+  });
+
+  return { events: sortEvents(events), nextInsertId };
+}
+
+function withEvent(
+  state: ReviewState,
+  eventId: string,
+  update: (event: ReviewEvent) => ReviewEvent,
+): ReviewState {
+  return {
+    ...state,
+    events: state.events.map((event) => (event.id === eventId ? update(event) : event)),
+  };
+}
+
+function markEdited(event: ReviewEvent): ReviewOrigin {
+  return event.origin === "recognizer" ? "edited" : event.origin;
+}
+
+export function removeNote(state: ReviewState, eventId: string, name: string): ReviewState {
+  return withEvent(state, eventId, (event) => {
+    if (event.notes.length <= 1) return event;
+    const notes = event.notes.filter((note) => noteName(note) !== name);
+    if (notes.length === event.notes.length) return event;
+    return { ...event, notes, origin: markEdited(event) };
+  });
+}
+
+export function addNote(state: ReviewState, eventId: string, note: ScoreNote): ReviewState {
+  return withEvent(state, eventId, (event) => {
+    if (event.notes.some((existing) => noteName(existing) === noteName(note))) return event;
+    return { ...event, notes: sortNotes([...event.notes, note]), origin: markEdited(event) };
+  });
+}
+
+export function toggleRemoved(state: ReviewState, eventId: string): ReviewState {
+  return withEvent(state, eventId, (event) => ({ ...event, removed: !event.removed }));
+}
+
+export function insertEvent(
+  state: ReviewState,
+  timeSec: number,
+  notes: ScoreNote[],
+  origin: ReviewOrigin,
+): ReviewState {
+  if (notes.length === 0) return state;
+  const id = `ins-${state.nextInsertId}`;
+  const event: ReviewEvent = {
+    id,
+    timeSec,
+    notes: sortNotes(notes),
+    origin,
+    removed: false,
+    sourceEventId: null,
+  };
+  return {
+    events: sortEvents([...state.events, event]),
+    nextInsertId: state.nextInsertId + 1,
+  };
+}
+
+export function activeEvents(state: ReviewState): ReviewEvent[] {
+  return state.events.filter((event) => !event.removed);
+}
+
+export function toCorrectionsPayload(state: ReviewState): CorrectionsPayload {
+  return {
+    version: 1,
+    events: activeEvents(state).map((event) => ({
+      timeSec: event.timeSec,
+      notes: event.notes.map(noteName),
+      origin: event.origin,
+    })),
+  };
+}
+
+/** DoReMiScore 表示用に ReviewEvent を ScoreEvent へ写像する。 */
+export function toDisplayScoreEvents(state: ReviewState): ScoreEvent[] {
+  return activeEvents(state).map((event, index) => ({
+    id: event.id,
+    startBeat: index,
+    durationBeat: 1,
+    startTimeSec: event.timeSec,
+    notes: event.notes,
+    isGlissLike: false,
+    gesture: "ambiguous",
+  }));
+}

--- a/apps/web/src/lib/reviewCorrections.ts
+++ b/apps/web/src/lib/reviewCorrections.ts
@@ -24,18 +24,24 @@ export type ReviewState = {
 
 const TIME_MATCH_TOLERANCE_SEC = 0.005;
 
+// サーバー側 PITCH_CLASS_TO_DOREMI (apps/api/app/transcription/constants.py) と同じ表記
 const DOREMI_BY_PITCH_CLASS: Record<string, string> = {
   C: "ド",
   "C#": "ド#",
+  Db: "レb",
   D: "レ",
   "D#": "レ#",
+  Eb: "ミb",
   E: "ミ",
   F: "ファ",
   "F#": "ファ#",
+  Gb: "ソb",
   G: "ソ",
   "G#": "ソ#",
+  Ab: "ラb",
   A: "ラ",
   "A#": "ラ#",
+  Bb: "シb",
   B: "シ",
 };
 
@@ -86,7 +92,7 @@ export function resolveScoreNote(
 ): ScoreNote | null {
   const known = knownNotes.get(name);
   if (known) return known;
-  const parsed = /^([A-G]#?)(\d)$/.exec(name);
+  const parsed = /^([A-G][#b]?)(\d)$/.exec(name);
   if (!parsed) return null;
   const tuningNote = tuning.notes.find((n) => n.noteName === name);
   if (!tuningNote) return null;

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -21,6 +21,24 @@ export type ScoreNote = {
   frequency: number;
 };
 
+export type AlternateGrouping = {
+  combinesWith: string[] | null;
+  combinedNotes: ScoreNote[] | null;
+  splitInto: ScoreNote[][] | null;
+  alternateNote: ScoreNote | null;
+  reason: string;
+  confidence: number;
+};
+
+export type CandidateSlot = {
+  startTime: number;
+  endTime: number;
+  primaryNote: ScoreNote;
+  candidates: ScoreNote[];
+  dropReason: string;
+  confidence: number;
+};
+
 export type ScoreEvent = {
   id: string;
   startBeat: number;
@@ -29,6 +47,21 @@ export type ScoreEvent = {
   notes: ScoreNote[];
   isGlissLike: boolean;
   gesture: string;
+  alternateGroupings?: AlternateGrouping[] | null;
+};
+
+export type ReviewOrigin = "recognizer" | "edited" | "inserted-slot" | "inserted-manual";
+
+export type CorrectionEventPayload = {
+  timeSec: number;
+  notes: string[];
+  origin: ReviewOrigin;
+};
+
+export type CorrectionsPayload = {
+  version: 1;
+  updatedAt?: string | null;
+  events: CorrectionEventPayload[];
 };
 
 export type NotationViews = {
@@ -42,6 +75,7 @@ export type TranscriptionResult = {
   instrumentTuning: InstrumentTuning;
   tempo: number;
   events: ScoreEvent[];
+  candidateSlots?: CandidateSlot[];
   notationViews: NotationViews;
   warnings: string[];
   debug?: Record<string, unknown> | null;

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -33,7 +33,9 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
-    ".next/dev/types/**/*.ts"
+    ".next/dev/types/**/*.ts",
+    ".next-dev/types/**/*.ts",
+    ".next-dev/dev/types/**/*.ts"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
## 概要

採譜結果をユーザーが確認・修正できる review ページ (`/score/{id}/review`) と、修正内容をサーバーに永続化する corrections API を追加する。

ロードマップ上の位置付け: 成功基準を「完全一致」から「編集コスト最小化」に再定義した流れの UI 側第一弾。**ユーザーの修正データ (corrections.json) は ground_truth.json と同じ語彙 (timeSec + note names) で保存される**ため、検証済みの修正をそのまま F1 ベンチマーク (scripts/audio-analysis/note_f1_benchmark.py) の ground truth に昇格できる。

## 対応 Issue

- #69 イベント単位試聴 (カード/譜面タップ → 該当区間のみ再生)
- #86 absolute timing contract — 既存 `startTimeSec` で充足することを確認 (schema 変更なし)
- #16 の方針反映: 閲覧ページ (ScoreViewer) は従来通り解析結果確認が主、編集 UI は専用ページに分離。undo / リセット / 明示保存 / beforeunload 警告で destructive 操作を保護
- #178 既存 schema の消費開始: alternateGroupings の soft-reject 候補を「認識器の次候補」として confidence 付き 1 タップ追加、candidateSlots を「ここに音?」ゴーストカードとして挿入可能に

## 実装

**API (commit 0e6bf91)**
- `GET/PUT /api/transcriptions/{id}/corrections` — corrections.json の取得/保存
- pydantic `CorrectionsPayload` (events: timeSec + notes[] + origin)。notes は min 1 要素
- pytest 5 件 (roundtrip / overwrite / validation / 404)

**Web (commit ae06e67)**
- 新ルート `/score/[transactionId]/review` + `ReviewEditor`
- 修正ロジックは `lib/reviewCorrections.ts` に pure 関数で分離 (add/remove note, 削除/復元, slot/手動挿入, corrections payload との往復) — vitest 10 件
- 既存 DoReMiScore を流用、修正結果が譜面に即時反映
- origin バッジ (認識 / 修正済 / 候補から追加 / 手動追加 / 削除済)

**Infra (commit a025bcd)**
- `NEXT_DIST_DIR` で distDir を分離可能に — 本番が同一 worktree の .next を serve しているため、ブランチ検証ビルドが本番成果物に触れないようにする

## 検証

- `uv run pytest apps/api/tests -q` → **422 passed**
- web: `tsc --noEmit` clean + vitest **62 passed**
- Playwright (mobile viewport 414×896, production build) で E2E 確認:
  - 旧 recognizer 出力に残っていた FP イベント (F4@11.8s, 物理検証でミュート接触音と確定済) を UI から削除 → 保存 → corrections.json が物理検証済み ground truth (D4+D5 ×5) と一致
  - 再読込で削除状態が復元され、保存ボタンが非活性 (dirty なし) に戻る

## スクリーンショット

モバイル幅 (414px) での確認画面。F4@11.8s (物理検証でミュート接触音=FP と確定済) を削除 → 保存 → 再読込後の状態。削除済イベントはゴースト表示で復元可能、楽譜には反映済み。

![review UI mobile screenshot](https://raw.githubusercontent.com/ayokura/kalimba-transcription/assets/pr-190/review-ui-final.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
