### PR TITLE
docs: refresh free-performance roadmap

### DIFF
--- a/docs/free-performance-readiness.md
+++ b/docs/free-performance-readiness.md
@@ -4,13 +4,14 @@
 
 各 recognizer コンポーネントについて、Free Performance（楽譜知識なし・Expected Performance なしの自由演奏転写）への適合度を評価する。チケット処理のたびに関連コンポーネントを再評価し、このドキュメントを更新する。
 
-**最終更新: 2026-06-27 (librosa-free 化 #193 を本文に反映 + F1 held-out caveat 追記。詳細 stage 評価の本体は 2026-04-16 時点)**
+**最終更新: 2026-06-28 (free-performance metrics 実装状況と次作業の整理を追記。詳細 stage 評価の本体は 2026-04-16 時点)**
 
-> **2026-06-27 重要注記 (先に読む):**
+> **2026-06-27/28 重要注記 (先に読む):**
 >
 > 1. **recognizer は完全に librosa-free (#193, 14584e2)。** 本文中で「`librosa.onset.onset_strength`」「librosa 依存」「broadband onset detector (librosa)」等と記述している箇所は **2026-04-16 (#187) 時点の歴史的記述**であり現在は誤り。`onset_strength` / `rms` / `onset_detect` / `peak_pick` / `backtrack` / `mel` は `segments.py` で pure-numpy 移植済 (librosa 0.11 と数値等価検証済)、production はさらに Rust 共有コア (`kalimba_dsp`) に委譲している。**HPSS path は #193 で drop 済**。librosa は分析スクリプト / skill でのみ使用 (`apps/api/app/transcription/` に import ゼロ)。
 > 2. **onset DSP は Rust/WASM 移植済で `/wasm-demo` で in-browser 稼働。** Stage 2 の Browser 評価が ⚠️ だった主因は「librosa 依存」だったが、その blocker は解消済。残るのは segment 化ロジック (active range / collector / gap rescue) の WASM 移植。
 > 3. **F1=1.000 は『成功』ではなく tuning-set 飽和のサイン。** 現在の F1 micro=1.000 は 6 録音の tuning-target set (**held-out ゼロ**) での再現であり、free-performance が解けたことを意味しない。真の品質 gate は #18 の harder 新録音 (録音 gated)。本ドキュメントの各 stage readiness はこの caveat 前提で読む。詳細は reassessment §3.2。
+> 4. **測定 skeleton は実装済み。** `scripts/audio-analysis/note_f1_benchmark.py` は one-best F1 だけでなく Candidate Recall@K / Correction Burden / HardMissRate / ConfidenceCalibration を出す。`review_priority_report.py` はその metrics と review status を結合する。次の blocker は指標の設計ではなく、テスター環境 corpus で baseline を保存し、review queue / #178 candidate schema / #111 chord selector の判断に接続すること。
 >
 > 新規の設計判断では、まず [`recognition-roadmap.md`](./recognition-roadmap.md) の現行 fixture 状態と、バイアス除去版の [`docs/research/20260626-unbiased-amt-reassessment.md`](./research/20260626-unbiased-amt-reassessment.md) を確認すること。本ファイルの詳細 stage 評価は 2026-04-16 時点の履歴として扱い、必要な stage から順次更新する。
 
@@ -376,6 +377,13 @@ line 191-215 の suppress/simplify 系関数群。大半は時間 + 周波数比
 - **patterns.py (Stage 6)** も同様に pure logic
 - segments.py の onset DSP は移植元 librosa 0.11 と数値等価検証済 (segments.py 冒頭の ISC 帰属 + 各 docstring 参照)。Rust 版も native/wasm parity を check_wasm.sh で pin
 
+### Evaluation / review loop
+
+- **測定 skeleton は実装済み**: `note_f1_benchmark.py` が one-best onset metrics、Candidate Recall@1/3/5、HardMissRate、Correction Burden、ConfidenceCalibration、debug ranked-candidate diagnostic recall を出す。
+- **次の整備対象は運用**: テスター環境の `ground_truth.json` corpus で baseline JSON を保存し、差分レポートを作る。
+- **review queue 接続**: `review_priority_report.py` が benchmark metrics と `review_status.json` を結合する。hard miss / correction burden が大きく、かつ review が open な録音を先に見る。
+- **#111 chord selector の前段**: sequential accept loop を先に直すのではなく、Candidate Recall / Correction Burden で「正解が候補には残っているのか」「完全に hard miss なのか」「どの candidate source で失われるのか」を分類してから設計する。
+
 ---
 
 ## 更新履歴
@@ -391,3 +399,4 @@ line 191-215 の suppress/simplify 系関数群。大半は時間 + 周波数比
 | 2026-04-09 | 34-key E83 fix + 34-key promote (`35bca12`, `7535464`) | Stage 3: `residual-forward-scan` を segment classifier として再利用する 2 段構成 fix (`residual-forward-scan-replaced-primary` + `forced_evidence_gates`) を「良い点」に追加。これにより 34-key BWV147 sequence-163 が 162/163 → 163/163 完全達成し、両 BWV147 sequence-163 fixture (17-key と 34-key) が completed regression target に。「懸念点」に新規課題 2 件追加: (1) 演奏者/テンポ違いに対する robustness の汎化検証 (現状は `residual-forward-scan` 発火 segment 限定)、(2) tertiary/secondary 区別の本質的是非 (将来の大規模リファクタ候補として記録) |
 | 2026-04-16 | #186 gap-rise rescue + #187 numba 排除 | Stage 2: gap-rise rescue を「良い点」に追加 (E148 C6 復活、17-key bwv147 164/164 completed 復帰)。Cross-cutting: onset_detect / beat_track の pure-numpy 化 (#187) を Streaming / Browser 両セクションに反映。numba がパイプラインの到達パスから排除され、残 librosa (onset_strength / HPSS / rms) は numba 非依存 |
 | 2026-06-27 | #193 librosa-free 完了の本文反映 + 研究再サーベイ整合 | ヘッダに重要注記を追加 (librosa-free #193 / onset DSP の Rust・WASM 移植 / F1=1.000 は held-out ゼロの tuning-set 飽和)。本文の「librosa.onset.onset_strength」「broadband onset detector (librosa)」「librosa 依存が onset_strength/HPSS/rms に集中」等の 2026-04-16 時点記述を訂正 (#193 で pure-numpy 移植 + Rust 委譲、HPSS path drop)。Stage 2 Browser 評価を ⚠️→🟡 (librosa blocker 解消、onset DSP は /wasm-demo で in-browser 稼働)。Cross-cutting Browser に #195 chunk_spectrum/rank_tuning_candidates の WASM 移植を反映 |
+| 2026-06-28 | free-performance metrics 実装状況の現状化 | `note_f1_benchmark.py` / `review_priority_report.py` が Candidate Recall / Correction Burden / review priority の skeleton を実装済みであることを追記。次作業を baseline 保存・review queue 接続・#178 candidate schema・#111 前段計測として整理 |

--- a/docs/recognition-roadmap.md
+++ b/docs/recognition-roadmap.md
@@ -37,9 +37,10 @@
 
 33 completed fixtures が安定した regression baseline を形成している。主な残課題:
 
-- **34-key R1 E83 carryover** ([#153](https://github.com/ayokura/kalimba-transcription/issues/153) scope 外): L6 E82 `<D5,B4,G4>` の D5 carryover が threshold 突破して E83 (expected `G4`) に extra D5 として追加される。`recent-carryover-candidate` / `weak-secondary-onset` 等の既存 gate 領域。次セッションで energy trace 確認 → 別 issue 起票 or override 判断
-- **heuristic constants の audit** ([#162](https://github.com/ayokura/kalimba-transcription/issues/162)): #153 Phase A + B + #154 で導入した 27 個の新定数の inventory、環境依存性の特定、data-driven 化候補の抽出。設計 audit のみ
-- **peaks redesign / chord selector** ([#111](https://github.com/ayokura/kalimba-transcription/issues/111)): `_evidence_rescue_gate` の複雑化、sequential accept loop の構造的制約。Phase A/B 完了後の再評価マイルストーン待ち
+- **free-performance 評価 loop の運用化** ([#18](https://github.com/ayokura/kalimba-transcription/issues/18), [#178](https://github.com/ayokura/kalimba-transcription/issues/178), [#194](https://github.com/ayokura/kalimba-transcription/issues/194)): `note_f1_benchmark.py` は Candidate Recall@K / Correction Burden / HardMissRate / ConfidenceCalibration を出せる。次はテスター環境の `ground_truth.json` corpus で baseline を保存し、`review_priority_report.py` と review queue を接続する。
+- **candidate schema / hard-drop 回避** ([#178](https://github.com/ayokura/kalimba-transcription/issues/178)): debug `rankedCandidates` / dropped `candidateSlots` を benchmark/report source として安定化し、順次 review UI / public response へ昇格する。onset gate の棄却も「捨てる」より低 confidence candidate 化を優先する。
+- **peaks redesign / chord selector** ([#111](https://github.com/ayokura/kalimba-transcription/issues/111)): `_evidence_rescue_gate` の複雑化、sequential accept loop の構造的制約。着手前に Candidate Recall / Correction Burden で「順序依存がどの hard miss / correction cost を生むか」を測る。
+- **heuristic constants の data-driven 化** ([#131](https://github.com/ayokura/kalimba-transcription/issues/131), [#172](https://github.com/ayokura/kalimba-transcription/issues/172), [#173](https://github.com/ayokura/kalimba-transcription/issues/173), [#174](https://github.com/ayokura/kalimba-transcription/issues/174)): #162 の inventory audit は完了済み。今後は RecognizerSettings / per-tine / per-recording / BPM-adaptive calibration へ分割された successor で進める。
 - **`arpeggio` modeling** ([#6](https://github.com/ayokura/kalimba-transcription/issues/6)): `slide_chord` との分離。Phase 1 設計は [arpeggio-design.md](arpeggio-design.md) に記載
 
 ### 解決済 (#153 Phase A + B / #154 / #186 で完了)
@@ -102,11 +103,12 @@ Strategy B の gap-candidate 設計と candidate/promotion プロトタイプは
 
 ## Immediate Next Engineering Tasks
 
-1. 33 completed fixtures の regression baseline を維持する
-2. peaks redesign (#111): chord selector による sequential accept loop の構造改善
-3. ranked candidate 不在問題 (#125): onset-focused FFT window 等の spectral acquisition 改善
-4. BWV147 full-sequence の pending 解消（onset detection 層 + post-processing debt）
-5. `arpeggio` Phase 1 の vocabulary 導入（[arpeggio-design.md](arpeggio-design.md) 参照）
+1. 33 completed fixtures の regression baseline を維持する (`uv run pytest apps/api/tests -q` / `test_manual_capture_completed.py`)。
+2. テスター環境の free-performance `ground_truth.json` corpus で `note_f1_benchmark.py --json` を実行し、Candidate Recall / Correction Burden / ConfidenceCalibration の baseline を保存する。
+3. `review_priority_report.py` と review queue / capture workflow を接続し、hard miss と correction burden が大きい録音を優先レビューできる状態にする。
+4. #178: benchmark-only の candidate sources (`alternateGroupings`, `candidateSlots`, debug `rankedCandidates`) を review UI / public response に昇格する最小 schema を設計する。
+5. #111 peaks redesign: 上記 metrics で sequential accept loop の実害を分類してから chord selector の最小リファクタに入る。
+6. `arpeggio` Phase 1 の vocabulary 導入（[arpeggio-design.md](arpeggio-design.md) 参照）。ただし評価は Candidate Recall / Correction Burden と paired sample で見る。
 
 ## 将来のサンプル収集マトリクス
 
@@ -253,3 +255,7 @@ strict four-note rerecord の例:
 - repetitions: `5`
 - spacing: take 間に約 `1s` の無音
 - success criteria: `5 events`、各 `E4+G4+B4+D5`
+
+## 更新履歴
+
+- 2026-06-28: docs/research の再サーベイと実装済み `note_f1_benchmark.py` / `review_priority_report.py` を反映。Immediate tasks を「chord selector 直行」から「free-performance metrics baseline → review priority → candidate schema → #111」へ並べ替え。

--- a/docs/research/20260626-amt-evaluation-survey.md
+++ b/docs/research/20260626-amt-evaluation-survey.md
@@ -240,6 +240,13 @@ free-performance 化に向けて、既存の fixture exact-match / note F1 だ�
 
 ### 3.1 `note_f1_benchmark.py` の拡張
 
+> **実装状況 (2026-06-28):** この節の初期 skeleton は `scripts/audio-analysis/note_f1_benchmark.py` に実装済み。
+> 現在の出力は one-best onset metrics、Candidate Recall@1/3/5、HardMissRate、Correction Burden、
+> event/candidate confidence calibration、debug `rankedCandidates` 診断 recall を含む。
+> `scripts/audio-analysis/review_priority_report.py` は、その metrics と `review_status.json` を結合し、
+> human review effort の優先順位を出す。
+> 以降の焦点は、指標定義の発明ではなく **baseline 保存・CI/レポート化・review queue 接続**。
+
 出力 JSON 例:
 
 ```json
@@ -329,7 +336,7 @@ Candidate Recall を測るには、benchmark 時に以下を集める必要が�
 現状 `rankedCandidates` / `secondaryDecisionTrail` は debug 限定。
 本番 response にすぐ出さなくても、benchmark JSON には出せるようにする。
 
-### 3.5 CI への入れ方
+### 3.5 CI / review queue への入れ方
 
 completed fixture exact-match は維持する。
 追加するなら別レイヤ:
@@ -338,9 +345,11 @@ completed fixture exact-match は維持する。
 - candidate recall report
 - correction burden report
 - confidence calibration report
+- review priority report (`review_priority_report.py`)
 
 合否条件は最初は厳しくしすぎない。
 まず baseline を保存し、差分を可視化する。
+テスター環境でのみ扱う録音データがあるため、CI に入れる場合も「データが存在するときだけ実行」する optional/report job から始める。
 
 ---
 
@@ -388,7 +397,7 @@ completed fixture exact-match はリファクタの安全網。
 
 ## 5. 現行方針への反映
 
-- 次の実装着手は `Candidate Recall` / `Correction Burden` の benchmark skeleton が最優先。
+- `Candidate Recall` / `Correction Burden` の benchmark skeleton は実装済み。次の実装着手は baseline JSON の保存・差分レポート・review queue への露出。
 - #178 multi-candidate は UI だけでなく評価可能性の基盤。
 - #18 corpus 収集では、free-performance audio だけでなく `ground_truth.json` の onset time / tolerance / method を同時に集める。
 - #194 quality indicators は、ECE / needs-review precision / high-confidence wrong rate で再較正する。
@@ -397,3 +406,4 @@ completed fixture exact-match はリファクタの安全網。
 
 - 2026-06-26: 新規作成。mir_eval / MIREX / AMT Challenge / onset annotation の観点を整理。
 - 2026-06-27: 評価指標担当サーベイ結果を主ソースとして全文再稿。mir_eval, PEAMT, Onsets and Frames, MV2H, AMT Challenge, calibration を反映。
+- 2026-06-28: `note_f1_benchmark.py` / `review_priority_report.py` の実装状況を反映し、次焦点を skeleton 実装から baseline/CI/review queue 接続へ更新。

--- a/docs/research/20260626-unbiased-amt-reassessment.md
+++ b/docs/research/20260626-unbiased-amt-reassessment.md
@@ -31,7 +31,7 @@
 | post-processing | events.py 約27パス。**ほぼ局所/因果的** (隣接1〜2 event 参照)。コーパス全体書き換えは patterns.py の repeated triad / four-note の2つのみ | `events.py`, `patterns.py` |
 | multi-candidate | `alternateGroupings` は通常 response に出る。`rankedCandidates`/`secondaryDecisionTrail`/`residualCandidates` は **debug 限定** | `pipeline.py`, `app/models.py` |
 | fixture | 35 total / 33 completed / 1 pending / 1 rerecord (実測) | `expected.json` 集計 |
-| 評価 | API テスト 501 pass (xdist 20 並列で ~37s)。F1 ベンチは既知フレーズで飽和傾向 | `pytest.ini`, `note_f1_benchmark.py` |
+| 評価 | API テスト 501 pass (xdist 20 並列で ~37s)。`note_f1_benchmark.py` は one-best F1 に加え Candidate Recall@K / Correction Burden / HardMissRate / ConfidenceCalibration を出す | `pytest.ini`, `note_f1_benchmark.py` |
 
 **旧サーベイとの主要な差分 (=旧サーベイのバイアス):**
 - 旧: 「onset gate 未実装」→ 実: 実装済み (弱 AND)。
@@ -121,15 +121,15 @@
 
 各項目に**測定可能な exit criteria** を付す。日付ではなく条件で進める。
 
-#### NOW — 測れる状態を作る (低リスク)
-- docs 現状化 (本コミットで roadmap / research-mapping は対応済み。free-performance-readiness も追随)。
-- `note_f1_benchmark.py` に Candidate Recall + Correction Burden を追加し CI 配線。
-- onset gate の棄却を「drop」ではなく「低 confidence の candidate slot へ降格」に統一。
-- **exit:** 自由演奏 GT 20件以上で「F1 / Candidate Recall / Correction Burden」が自動計測され
-  ベースライン確立。
+#### NOW — 測定 skeleton を運用 loop に接続する (低リスク)
+- docs 現状化 (roadmap / research / free-performance-readiness の優先順位を、実装済み benchmark 前提へ更新)。
+- `note_f1_benchmark.py --json` の出力をテスター環境で baseline 保存し、差分レポート化する。
+- `review_priority_report.py` を review queue / capture workflow の運用に接続し、human review effort を hard miss / correction burden が大きい録音へ向ける。
+- onset gate の棄却を「drop」ではなく「低 confidence の candidate slot へ降格」に統一する設計を、#178 candidate schema と合わせて詰める。
+- **exit:** 自由演奏 GT 20件以上で「F1 / Candidate Recall / Correction Burden / review priority」が自動計測され、baseline と差分が保存される。
 
 #### NEXT — 候補保持の作り込み + 物理モデルは検証のみ
-- #178: debug 限定の rankedCandidates / dropped segment を**本出力 + review UI** に昇格。
+- #178: debug 限定の rankedCandidates / dropped segment を、まず benchmark/report source として安定化し、その後 **本出力 + review UI** に昇格。
 - #18: 自由演奏 corpus を増やす (mixed / strict / slide / arpeggio-like、録音環境を変える、
   `ground_truth.json` の `method` を明記)。
 - per-tine partial / note-state machine は **research branch の spike** (dual-run、main 投入は判断保留)。
@@ -195,3 +195,4 @@ DOI / 公式実装へ戻って確認する。
 ## 履歴
 - 2026-06-26: 新規作成。`20260406-*` のバイアス除去・現実装事実との再突合・最新研究 (Basic Pitch /
   PESTO / MT3 系 / AMT bias) の再収集を反映。
+- 2026-06-28: Candidate Recall / Correction Burden benchmark 実装後の現状へ更新。NOW を「指標 skeleton 実装」から「baseline 保存・review queue 接続・#178 candidate schema」へ移動。

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -29,7 +29,7 @@
 
 mir_eval / PEAMT / Onsets and Frames / MV2H / AMT Challenge / calibration をもとに、Candidate Recall@K、Correction Burden、ConfidenceCalibration の位置づけを整理。
 
-次の実装候補である `note_f1_benchmark.py` 拡張時に参照する。
+`note_f1_benchmark.py` は 2026-06-28 時点でこの骨格を実装済み。次は、その出力を review queue / CI / #18 free-performance corpus 拡張へ接続する。
 
 ### 3. Product UX / correction workflow
 
@@ -83,16 +83,24 @@ per-tine partial / note-state / resonance handling の spike 前に参照する�
 
 ## 次にやるなら
 
-最も自然な次作業は、`note_f1_benchmark.py` に以下の skeleton を追加すること。
+`note_f1_benchmark.py` には、以下の free-performance 評価 skeleton が実装済み。
 
 - onset-only one-best metrics
 - Candidate Recall@K
 - Correction Burden の粗い編集コスト
 - HardMissRate
 - ConfidenceCalibration の初期集計
+- debug `rankedCandidates` / `candidateSlots` を使った診断 recall
 
-その後、#18 の free-performance corpus 拡張と #178 の candidate output schema を接続する。
+次の自然な作業は、**測定値を運用ループへ接続すること**。
+
+1. テスター環境の `ground_truth.json` corpus で `note_f1_benchmark.py --json` を定期実行し、baseline JSON を保存する。
+2. `review_priority_report.py` を review queue の運用メモに接続し、「どの録音を見ると recognizer 改善に効くか」を見える化する。
+3. #18 の free-performance corpus 拡張では、録音だけでなく onset `ground_truth.json` / tolerance / annotation method を同時に集める。
+4. #178 multi-candidate output schema は、benchmark-only の candidate sources を review UI / public response に昇格する順序で進める。
+5. #111 chord selector redesign は、上記指標で「sequential accept loop がどの correction burden を生んでいるか」を測ってから着手する。
 
 ## 履歴
 
 - 2026-06-27: 新規作成。2026-06-26/27 再サーベイが一段落したため、読み順と設計判断上の優先文書を整理。
+- 2026-06-28: `note_f1_benchmark.py` / `review_priority_report.py` の実装状況を反映し、次作業を skeleton 実装から baseline 運用・review queue 接続・#111 前段計測へ更新。

--- a/docs/task-management.md
+++ b/docs/task-management.md
@@ -116,20 +116,29 @@ This is where recording intent, rerecord guidance, fixture status, and audit not
 
 ## Current Medium-Term Themes
 
-1. gesture classification
-   - strict chord
-   - `slide_chord`
-   - `slide_chord` / sweep
-   - ambiguous
-2. debug review UX
+1. free-performance evaluation loop
+   - `note_f1_benchmark.py --json` baseline preservation
+   - Candidate Recall / Correction Burden / ConfidenceCalibration trend reports
+   - review priority report connected to review queue
+2. candidate-aware review UX
+   - `candidateSlots` / `alternateGroupings` / debug `rankedCandidates` surfaced with provenance
    - expected vs detected diff
    - rerecord / review-needed states
    - fragment warnings
-3. editor UX
+3. gesture classification
+   - strict chord
+   - `slide_chord`
+   - `slide_chord` / sweep
+   - `arpeggio`
+   - ambiguous
+4. editor UX
+   - enable candidate slot
+   - replace note from candidate
    - merge as chord
    - bundle as `slide_chord`
-4. broader recognition robustness
+5. broader recognition robustness
    - contact noise
    - room noise
    - mic position variance
+   - hard drops from sequential accept / chord selection
 


### PR DESCRIPTION
## Summary
- Reflect that note_f1_benchmark now emits Candidate Recall, Correction Burden, HardMissRate, and confidence calibration metrics
- Reorder the near-term roadmap around baseline preservation, review-priority reporting, candidate schema work, then #111 chord selector
- Update research index, evaluation survey, readiness notes, and task-management themes to avoid stale "implement the skeleton next" guidance

## Test Plan
- uv run pytest apps/api/tests/test_note_f1_benchmark_metrics.py apps/api/tests/test_review_priority_report.py -q
- uv run python scripts/audio-analysis/note_f1_benchmark.py --help
- uv run python scripts/audio-analysis/review_priority_report.py --help
- git diff --check