### PR TITLE
ci: update actions runtime and use Node 24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,16 +15,18 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.0
 
       - uses: flatt-security/setup-takumi-guard-pypi@v1
         with:
           bot-id: "BT01KP0J2WVXM2XRECK5RCT62XRH" # ayokura
 
-      - uses: astral-sh/setup-uv@v6
+      # Pinned to astral-sh/setup-uv v8.2.0 commit for supply-chain hardening.
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
         with:
           version: "latest"
           enable-cache: true
+          cache-suffix: test
 
       - name: Set up Python
         run: uv python install 3.14
@@ -57,16 +59,18 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.0
 
       - uses: flatt-security/setup-takumi-guard-pypi@v1
         with:
           bot-id: "BT01KP0J2WVXM2XRECK5RCT62XRH" # ayokura
 
-      - uses: astral-sh/setup-uv@v6
+      # Pinned to astral-sh/setup-uv v8.2.0 commit for supply-chain hardening.
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
         with:
           version: "latest"
           enable-cache: true
+          cache-suffix: wasm
 
       - name: Set up Python
         run: uv python install 3.14
@@ -80,12 +84,12 @@ jobs:
         with:
           workspaces: crates/kalimba-dsp
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6.4.0
         with:
-          node-version: "22"
+          node-version: "24"
 
-      - name: Install wasm-pack (prebuilt binary)
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - name: Install wasm-pack
+        run: cargo install wasm-pack --version 0.15.0 --locked
 
       - name: Install dependencies (native kalimba_dsp reference build)
         run: uv sync --dev
@@ -98,11 +102,11 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6.4.0
         with:
-          node-version: "22"
+          node-version: "24"
           cache: npm
 
       - name: Install dependencies

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,7 +20,7 @@
     "@playwright/test": "^1.61.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
-    "@types/node": "^25.6.0",
+    "@types/node": "^24.13.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "fake-indexeddb": "^6.2.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@playwright/test": "^1.61.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
-        "@types/node": "^25.6.0",
+        "@types/node": "^24.13.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "fake-indexeddb": "^6.2.5",
@@ -28,6 +28,23 @@
         "typescript": "^6.0.2",
         "vitest": "^4.1.4"
       }
+    },
+    "apps/web/node_modules/@types/node": {
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "apps/web/node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "5.1.11",
@@ -1366,6 +1383,8 @@
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -2297,6 +2316,7 @@
       "version": "2.3.2",
       "resolved": "https://npm.flatt.tech/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2696,7 +2716,9 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/vite": {
       "version": "8.0.8",


### PR DESCRIPTION
## Summary
- Update GitHub-hosted actions to Node 24 runtime-compatible releases:
  - `actions/checkout@v7.0.0`
  - `actions/setup-node@v6.4.0`
- Pin `astral-sh/setup-uv` to the latest v8.2.0 commit SHA for supply-chain hardening.
- Add per-job `setup-uv` cache suffixes to avoid parallel cache-save warnings.
- Run CI web/wasm Node.js jobs on Node 24.
- Replace wasm-pack install from `curl | sh` with `cargo install wasm-pack --locked`.
- Align web `@types/node` with Node 24.

## Verification
- Confirmed updated actions use `node24` action runtime.
- `npm ci`
- Node 24 (`v24.18.0`) web checks:
  - `npx next typegen`
  - `npm --workspace apps/web run lint`
  - `npm --workspace apps/web run test` (82 passed)
  - `npm --workspace apps/web run e2e` (10 passed)
- `uv sync --dev && uv run pytest apps/api/tests -q` (543 passed)

Note: local environment does not currently have `cargo` installed, so the wasm check is verified by GitHub Actions after `dtolnay/rust-toolchain@stable` provisions Cargo in CI.
