### PR TITLE
feat(#204 Phase 2-3): recognition-run switcher UI, queue stale badge, corrections baseRunId, bulk re-recognition tool

### DIFF
--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -26,7 +26,7 @@ from .storage import (
     get_data_dir,
     get_transaction_audio_sha256,
     get_transaction_timestamps,
-    latest_run_id,
+    latest_displayed_run_id,
     list_recent_transactions,
     list_review_queue,
     list_runs,
@@ -510,13 +510,15 @@ def get_transcription_runs(transaction_id: str) -> dict:
 
     Newest-first list of runs plus a synthetic ``legacy`` entry for the
     immutable upload-time response. ``latestRunId`` is the run the read
-    endpoints currently resolve to (``"legacy"`` when no re-recognition run
-    exists yet)."""
+    endpoints actually resolve to — the newest *readable* run (``"legacy"`` when
+    no re-recognition run exists yet, or when the newest run's response is
+    unreadable and display falls back), so a client keying its selector off
+    ``latestRunId`` stays aligned with the shown payload (#209 review)."""
     _validate_transaction_id(transaction_id)
     if not transaction_exists(transaction_id):
         raise HTTPException(status_code=404, detail="Transaction not found.")
     runs = list_runs(transaction_id)
-    resolved = latest_run_id(transaction_id) or ("legacy" if runs else None)
+    resolved = latest_displayed_run_id(transaction_id) or ("legacy" if runs else None)
     return {"runs": runs, "latestRunId": resolved}
 
 

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -37,6 +37,7 @@ from .storage import (
     load_memo,
     load_request,
     load_review_status,
+    load_run_or_legacy_response,
     quarantine_corrections,
     save_corrections,
     save_memo,
@@ -517,6 +518,27 @@ def get_transcription_runs(transaction_id: str) -> dict:
     runs = list_runs(transaction_id)
     resolved = latest_run_id(transaction_id) or ("legacy" if runs else None)
     return {"runs": runs, "latestRunId": resolved}
+
+
+@app.get("/api/transcriptions/{transaction_id}/runs/{run_id}")
+def get_transcription_run(transaction_id: str, run_id: str) -> dict:
+    """A single historical run's full payload (#204 Phase 2).
+
+    ``GET .../runs`` only returns summaries (meta + eventCount) so the
+    run-switcher UI can list history cheaply; this endpoint serves the full
+    response for whichever run the user selects, including the synthetic
+    ``"legacy"`` id for the immutable upload-time response."""
+    _validate_transaction_id(transaction_id)
+    if not transaction_exists(transaction_id):
+        raise HTTPException(status_code=404, detail="Transaction not found.")
+    data = load_run_or_legacy_response(transaction_id, run_id)
+    if data is None:
+        raise HTTPException(status_code=404, detail="Run not found.")
+    timestamps = get_transaction_timestamps(transaction_id)
+    if timestamps is not None:
+        data["transcribedAt"] = timestamps["transcribedAt"]
+        data["audioFirstSeenAt"] = timestamps["audioFirstSeenAt"]
+    return data
 
 
 @app.post("/api/transcriptions/{transaction_id}/runs")

--- a/apps/api/app/models.py
+++ b/apps/api/app/models.py
@@ -120,6 +120,14 @@ class CorrectionEvent(BaseModel):
 class CorrectionsPayload(BaseModel):
     version: Literal[1] = 1
     updated_at: str | None = Field(default=None, alias="updatedAt")
+    # #204 Phase 3: which recognition run these corrections were made against
+    # ("legacy" for the immutable upload-time response, or a runId from
+    # GET .../runs). Optional so pre-#204 saved corrections keep validating as
+    # "unknown base" rather than failing. This is provenance for future
+    # tooling (e.g. GT promotion, staleness display) - the review UI's onset
+    # rematching (reviewCorrections.ts, +/-50ms window) already tolerates
+    # re-recognition drift independently of this field.
+    base_run_id: str | None = Field(default=None, alias="baseRunId")
     events: list[CorrectionEvent]
 
     model_config = {"populate_by_name": True}

--- a/apps/api/app/storage.py
+++ b/apps/api/app/storage.py
@@ -171,19 +171,20 @@ def list_review_queue(limit: int, status: str | None = None) -> list[dict]:
     return results
 
 
-def _resolved_recognizer_fingerprint(tx_dir: Path) -> str | None:
-    """recognizerFingerprint of whichever response a listing currently shows
-    for this transaction (latest run if one exists, else the legacy
-    request.json value). Compared against the running process's own
-    ``recognizer_fingerprint()`` to flag "saved != current recognizer" in
-    listings (#204 Phase 2)."""
-    transaction_id = tx_dir.name
+def resolved_recognizer_fingerprint(transaction_id: str) -> str | None:
+    """recognizerFingerprint of whichever response is currently resolved for
+    this transaction (latest run if one exists, else the legacy
+    request.json value). Public so both listings (``_summarize_transaction``,
+    compared against the running process's own ``recognizer_fingerprint()``
+    to flag "saved != current recognizer") and external tooling (e.g.
+    ``scripts/audio-analysis/bulk_recognition_runs.py``, #204 Phase 3) can
+    determine staleness without duplicating the resolution logic."""
     run_id = latest_run_id(transaction_id)
     if run_id is not None:
         meta = load_run_meta(transaction_id, run_id)
         if meta is not None:
             return meta.get("recognizerFingerprint")
-    request_path = tx_dir / "request.json"
+    request_path = get_transaction_dir(transaction_id) / "request.json"
     if not request_path.exists():
         return None
     try:
@@ -226,7 +227,7 @@ def _summarize_transaction(tx_dir: Path) -> dict | None:
     # plus whether it differs from the recognizer running right now, so the
     # review queue can flag re-recognition candidates. None when the saved
     # fingerprint is unknown (pre-#204 recordings) rather than guessing stale.
-    saved_fingerprint = _resolved_recognizer_fingerprint(tx_dir)
+    saved_fingerprint = resolved_recognizer_fingerprint(tx_dir.name)
     is_stale = None if saved_fingerprint is None else saved_fingerprint != recognizer_fingerprint()
     return {
         "transactionId": tx_dir.name,

--- a/apps/api/app/storage.py
+++ b/apps/api/app/storage.py
@@ -7,6 +7,8 @@ import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 
+from .fingerprints import recognizer_fingerprint
+
 
 def get_data_dir() -> Path:
     return Path(os.environ.get("KALIMBA_DATA_DIR", "data"))
@@ -169,6 +171,28 @@ def list_review_queue(limit: int, status: str | None = None) -> list[dict]:
     return results
 
 
+def _resolved_recognizer_fingerprint(tx_dir: Path) -> str | None:
+    """recognizerFingerprint of whichever response a listing currently shows
+    for this transaction (latest run if one exists, else the legacy
+    request.json value). Compared against the running process's own
+    ``recognizer_fingerprint()`` to flag "saved != current recognizer" in
+    listings (#204 Phase 2)."""
+    transaction_id = tx_dir.name
+    run_id = latest_run_id(transaction_id)
+    if run_id is not None:
+        meta = load_run_meta(transaction_id, run_id)
+        if meta is not None:
+            return meta.get("recognizerFingerprint")
+    request_path = tx_dir / "request.json"
+    if not request_path.exists():
+        return None
+    try:
+        data = json.loads(request_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data.get("recognizerFingerprint")
+
+
 def _summarize_transaction(tx_dir: Path) -> dict | None:
     request_path = tx_dir / "request.json"
     response_path = tx_dir / "response.json"
@@ -198,6 +222,12 @@ def _summarize_transaction(tx_dir: Path) -> dict | None:
             memo_text = memo_path.read_text(encoding="utf-8")
         except OSError:
             memo_text = None
+    # #204 Phase 2: expose the fingerprint the shown response was produced with,
+    # plus whether it differs from the recognizer running right now, so the
+    # review queue can flag re-recognition candidates. None when the saved
+    # fingerprint is unknown (pre-#204 recordings) rather than guessing stale.
+    saved_fingerprint = _resolved_recognizer_fingerprint(tx_dir)
+    is_stale = None if saved_fingerprint is None else saved_fingerprint != recognizer_fingerprint()
     return {
         "transactionId": tx_dir.name,
         "createdAt": audio_path.stat().st_mtime,
@@ -215,6 +245,8 @@ def _summarize_transaction(tx_dir: Path) -> dict | None:
         # time.  None for payloads stored before qualityIndicators existed.
         "qualityDifficulty": (response_data.get("qualityIndicators") or {}).get("difficulty"),
         "qualityFlag": (response_data.get("qualityIndicators") or {}).get("flag"),
+        "recognizerFingerprint": saved_fingerprint,
+        "isStale": is_stale,
     }
 
 
@@ -395,6 +427,18 @@ def load_latest_response(transaction_id: str) -> dict | None:
     if latest is not None:
         return latest
     return load_response(transaction_id)
+
+
+def load_run_or_legacy_response(transaction_id: str, run_id: str) -> dict | None:
+    """Full response payload for a specific run id (#204 Phase 2).
+
+    ``run_id == "legacy"`` resolves to the immutable upload-time response, the
+    same synthetic id ``list_runs`` uses for it, so a run-switcher UI can treat
+    every entry from ``GET .../runs`` uniformly. Returns None when the run (or
+    the legacy response) does not exist."""
+    if run_id == "legacy":
+        return load_response(transaction_id)
+    return load_run_response(transaction_id, run_id)
 
 
 def list_runs(transaction_id: str) -> list[dict]:

--- a/apps/api/app/storage.py
+++ b/apps/api/app/storage.py
@@ -204,6 +204,19 @@ def resolved_recognizer_fingerprint(transaction_id: str) -> str | None:
     return resolved_output_fingerprints(transaction_id)[0]
 
 
+def latest_displayed_run_id(transaction_id: str) -> str | None:
+    """Run id whose response ``load_latest_response`` actually returns — the
+    newest *readable* run, else None (caller falls back to the legacy response).
+
+    Callers that must stay aligned with the shown payload (e.g. the /runs
+    ``latestRunId`` the score viewer initializes its selector from, #209 review)
+    should use this rather than ``latest_run_id``: when the newest run directory
+    has an unreadable response.json, display resolution skips it, and a selector
+    keyed off ``latest_run_id`` would otherwise point at a run that is not shown
+    (and whose GET .../runs/{id} 404s)."""
+    return _latest_readable_run_id_for_dir(get_transaction_dir(transaction_id))
+
+
 def is_response_stale(transaction_id: str) -> bool | None:
     """Whether the displayed response was produced by a different recognizer
     *output* than the one running now — the single source of truth for both the

--- a/apps/api/app/storage.py
+++ b/apps/api/app/storage.py
@@ -7,7 +7,7 @@ import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 
-from .fingerprints import recognizer_fingerprint
+from .fingerprints import kalimba_dsp_fingerprint, recognizer_fingerprint
 
 
 def get_data_dir() -> Path:
@@ -171,27 +171,62 @@ def list_review_queue(limit: int, status: str | None = None) -> list[dict]:
     return results
 
 
-def resolved_recognizer_fingerprint(transaction_id: str) -> str | None:
-    """recognizerFingerprint of whichever response is currently resolved for
-    this transaction (latest run if one exists, else the legacy
-    request.json value). Public so both listings (``_summarize_transaction``,
-    compared against the running process's own ``recognizer_fingerprint()``
-    to flag "saved != current recognizer") and external tooling (e.g.
-    ``scripts/audio-analysis/bulk_recognition_runs.py``, #204 Phase 3) can
-    determine staleness without duplicating the resolution logic."""
-    run_id = latest_run_id(transaction_id)
+def resolved_output_fingerprints(transaction_id: str) -> tuple[str | None, str | None]:
+    """(recognizerFingerprint, dspFingerprint) of whichever response is currently
+    *displayed* for this transaction: the newest run whose response.json actually
+    loads, else the legacy request.json values.
+
+    Resolving from the run that ``_load_latest_response_for_dir`` actually reads
+    — not merely ``latest_run_id()`` — keeps the flagged fingerprints aligned with
+    the response the UI shows (#209 review): a newest run whose response.json is
+    present but unreadable must not lend its (fresh) meta to an older response that
+    is what actually gets displayed."""
+    tx_dir = get_transaction_dir(transaction_id)
+    run_id = _latest_readable_run_id_for_dir(tx_dir)
     if run_id is not None:
-        meta = load_run_meta(transaction_id, run_id)
-        if meta is not None:
-            return meta.get("recognizerFingerprint")
-    request_path = get_transaction_dir(transaction_id) / "request.json"
+        meta = load_run_meta(transaction_id, run_id) or {}
+        return meta.get("recognizerFingerprint"), meta.get("dspFingerprint")
+    request_path = tx_dir / "request.json"
     if not request_path.exists():
-        return None
+        return None, None
     try:
         data = json.loads(request_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
+        return None, None
+    return data.get("recognizerFingerprint"), data.get("dspFingerprint")
+
+
+def resolved_recognizer_fingerprint(transaction_id: str) -> str | None:
+    """recognizerFingerprint of the displayed response (see
+    ``resolved_output_fingerprints``). Kept for external tooling
+    (``scripts/audio-analysis/bulk_recognition_runs.py``, #204 Phase 3) that
+    reports the recognizer fingerprint on its own."""
+    return resolved_output_fingerprints(transaction_id)[0]
+
+
+def is_response_stale(transaction_id: str) -> bool | None:
+    """Whether the displayed response was produced by a different recognizer
+    *output* than the one running now — the single source of truth for both the
+    review-queue ``isStale`` badge and the bulk re-recognition tool's freshness
+    filter (#204 Phase 2 / #209 review).
+
+    Compares a composite of the recognizer (Python transcription sources) and the
+    kalimba_dsp (Rust extension) fingerprints, because a DSP-only change leaves
+    ``recognizer_fingerprint()`` unchanged yet still alters the output.
+
+    - ``None``  — recognizer fingerprint unknown (pre-#204 recordings); do not guess.
+    - ``True``  — recognizer differs, or recognizer matches but a *known* saved DSP
+      fingerprint differs from the current one.
+    - ``False`` — recognizer matches and the DSP fingerprint matches (or the saved
+      DSP fingerprint is unknown, in which case we do not fabricate staleness)."""
+    saved_recognizer, saved_dsp = resolved_output_fingerprints(transaction_id)
+    if saved_recognizer is None:
         return None
-    return data.get("recognizerFingerprint")
+    if saved_recognizer != recognizer_fingerprint():
+        return True
+    if saved_dsp is not None and saved_dsp != kalimba_dsp_fingerprint():
+        return True
+    return False
 
 
 def _summarize_transaction(tx_dir: Path) -> dict | None:
@@ -224,11 +259,12 @@ def _summarize_transaction(tx_dir: Path) -> dict | None:
         except OSError:
             memo_text = None
     # #204 Phase 2: expose the fingerprint the shown response was produced with,
-    # plus whether it differs from the recognizer running right now, so the
-    # review queue can flag re-recognition candidates. None when the saved
-    # fingerprint is unknown (pre-#204 recordings) rather than guessing stale.
+    # plus whether it differs from the recognizer output running right now, so the
+    # review queue can flag re-recognition candidates. isStale is a composite of
+    # the recognizer + kalimba_dsp fingerprints (#209 review) and is None when the
+    # saved fingerprint is unknown (pre-#204 recordings) rather than guessing stale.
     saved_fingerprint = resolved_recognizer_fingerprint(tx_dir.name)
-    is_stale = None if saved_fingerprint is None else saved_fingerprint != recognizer_fingerprint()
+    is_stale = is_response_stale(tx_dir.name)
     return {
         "transactionId": tx_dir.name,
         "createdAt": audio_path.stat().st_mtime,
@@ -399,9 +435,11 @@ def load_run_meta(transaction_id: str, run_id: str) -> dict | None:
         return None
 
 
-def _load_latest_response_for_dir(tx_dir: Path) -> dict | None:
-    """Newest readable run response for a tx dir, else None. Legacy fallback is
-    the caller's responsibility."""
+def _latest_readable_run_id_for_dir(tx_dir: Path) -> str | None:
+    """Newest run id whose response.json is present *and* parseable — the run
+    ``_load_latest_response_for_dir`` actually displays. None if no run has a
+    readable response. Shared so staleness metadata can be read from the same run
+    whose response loads (#209 review)."""
     runs_dir = tx_dir / "runs"
     if not runs_dir.is_dir():
         return None
@@ -413,10 +451,24 @@ def _load_latest_response_for_dir(tx_dir: Path) -> dict | None:
     for run_id in reversed(run_ids):
         path = runs_dir / run_id / "response.json"
         try:
-            return json.loads(path.read_text(encoding="utf-8"))
+            json.loads(path.read_text(encoding="utf-8"))
+            return run_id
         except (OSError, json.JSONDecodeError):
             continue
     return None
+
+
+def _load_latest_response_for_dir(tx_dir: Path) -> dict | None:
+    """Newest readable run response for a tx dir, else None. Legacy fallback is
+    the caller's responsibility."""
+    run_id = _latest_readable_run_id_for_dir(tx_dir)
+    if run_id is None:
+        return None
+    path = tx_dir / "runs" / run_id / "response.json"
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
 
 
 def load_latest_response(transaction_id: str) -> dict | None:

--- a/apps/api/tests/test_corrections.py
+++ b/apps/api/tests/test_corrections.py
@@ -65,6 +65,31 @@ def test_corrections_roundtrip():
     assert get_response.json()["corrections"] == saved
 
 
+def test_corrections_base_run_id_roundtrip():
+    """#204 Phase 3: corrections optionally record which recognition run they
+    were made against (runId, or the synthetic "legacy" id)."""
+    tid = _create_transaction()
+    payload = {
+        "version": 1,
+        "baseRunId": "legacy",
+        "events": [{"timeSec": 1.0, "notes": ["C4"], "origin": "recognizer"}],
+    }
+    put_response = client.put(f"/api/transcriptions/{tid}/corrections", json=payload)
+    assert put_response.status_code == 200
+    saved = put_response.json()["corrections"]
+    assert saved["baseRunId"] == "legacy"
+
+    get_response = client.get(f"/api/transcriptions/{tid}/corrections")
+    assert get_response.json()["corrections"]["baseRunId"] == "legacy"
+
+
+def test_corrections_base_run_id_omitted_defaults_to_none():
+    tid = _create_transaction()
+    payload = {"version": 1, "events": [{"timeSec": 1.0, "notes": ["C4"]}]}
+    put_response = client.put(f"/api/transcriptions/{tid}/corrections", json=payload)
+    assert put_response.json()["corrections"]["baseRunId"] is None
+
+
 def test_corrections_overwrite_replaces_previous():
     tid = _create_transaction()
     first = {"version": 1, "events": [{"timeSec": 1.0, "notes": ["C4"]}]}

--- a/apps/api/tests/test_recognition_runs.py
+++ b/apps/api/tests/test_recognition_runs.py
@@ -222,7 +222,7 @@ def test_review_queue_fingerprint_resolves_from_readable_run():
     look fresh)."""
     tid = _create_transaction()
     # Older, readable run recorded with a stale recognizer fingerprint.
-    storage.create_run(
+    older = storage.create_run(
         tid, {"events": []}, None,
         commit_sha=None, recognizer_fingerprint="0ldfp0000stale00", dsp_fingerprint=None,
     )
@@ -239,6 +239,11 @@ def test_review_queue_fingerprint_resolves_from_readable_run():
     entry = _queue_entry(tid)
     assert entry["recognizerFingerprint"] == "0ldfp0000stale00"
     assert entry["isStale"] is True
+
+    # /runs latestRunId must follow the displayed (readable) run, not the corrupt
+    # newest one, so a client selector stays aligned with what is shown (#209).
+    runs_body = client.get(f"/api/transcriptions/{tid}/runs").json()
+    assert runs_body["latestRunId"] == older["runId"]
 
 
 def test_review_queue_isstale_none_when_fingerprint_unknown():

--- a/apps/api/tests/test_recognition_runs.py
+++ b/apps/api/tests/test_recognition_runs.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 from conftest import client, synthesize_note, wav_bytes
 from app import storage
+from app.fingerprints import recognizer_fingerprint
 
 RUN_ID_RE = re.compile(r"^\d{8}T\d{6}\.\d{6}Z-[0-9a-z]{8}$")
 MISSING_ID = "00000000-0000-0000-0000-000000000000"
@@ -154,6 +155,48 @@ def test_get_runs_unknown_transaction_404():
     assert client.get(f"/api/transcriptions/{MISSING_ID}/runs").status_code == 404
 
 
+def _queue_entry(tid: str) -> dict:
+    rows = client.get("/api/review-queue?limit=200").json()
+    return next(r for r in rows if r["transactionId"] == tid)
+
+
+def test_review_queue_flags_stale_when_saved_fingerprint_differs():
+    """#204 Phase 2: queue rows expose recognizerFingerprint/isStale so a
+    "saved != current recognizer" badge can be shown."""
+    tid = _create_transaction()
+    current_fp = recognizer_fingerprint()
+
+    # A freshly created transaction's request.json records the current
+    # fingerprint, so its (legacy) resolved response is not stale.
+    entry = _queue_entry(tid)
+    assert entry["recognizerFingerprint"] == current_fp
+    assert entry["isStale"] is False
+
+    # A sentinel run recorded with a different fingerprint becomes the newest
+    # resolved response, flipping isStale to True.
+    storage.create_run(
+        tid, {"events": []}, None,
+        commit_sha=None, recognizer_fingerprint="deadbeefcafef00d", dsp_fingerprint=None,
+    )
+    entry = _queue_entry(tid)
+    assert entry["recognizerFingerprint"] == "deadbeefcafef00d"
+    assert entry["isStale"] is True
+
+
+def test_review_queue_isstale_none_when_fingerprint_unknown():
+    """Pre-#204 recordings have no recognizerFingerprint in request.json; the
+    queue must not guess staleness for them (None, not True/False)."""
+    tid = _create_transaction()
+    request_path = _tx_root() / tid / "request.json"
+    request_data = json.loads(request_path.read_text(encoding="utf-8"))
+    request_data.pop("recognizerFingerprint", None)
+    request_path.write_text(json.dumps(request_data), encoding="utf-8")
+
+    entry = _queue_entry(tid)
+    assert entry["recognizerFingerprint"] is None
+    assert entry["isStale"] is None
+
+
 def test_recent_listing_reflects_latest_run_event_count():
     tid = _create_transaction()
     sentinel_events = [
@@ -171,6 +214,43 @@ def test_recent_listing_reflects_latest_run_event_count():
     recent = client.get("/api/transcriptions/recent?limit=100").json()
     entry = next(e for e in recent if e["transactionId"] == tid)
     assert entry["eventCount"] == 7
+
+
+def test_get_specific_run_by_id():
+    tid = _create_transaction()
+    run_id = client.post(f"/api/transcriptions/{tid}/runs").json()["runId"]
+
+    resp = client.get(f"/api/transcriptions/{tid}/runs/{run_id}")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert isinstance(body["events"], list)
+    assert "transcribedAt" in body
+    assert "audioFirstSeenAt" in body
+
+
+def test_get_legacy_run_by_synthetic_id():
+    tid = _create_transaction()
+    legacy = storage.load_response(tid)
+    # Appending a fresh run must not disturb the legacy synthetic id's content.
+    client.post(f"/api/transcriptions/{tid}/runs")
+
+    resp = client.get(f"/api/transcriptions/{tid}/runs/legacy")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["events"] == legacy["events"]
+
+
+def test_get_run_unknown_run_id_404():
+    tid = _create_transaction()
+    assert client.get(f"/api/transcriptions/{tid}/runs/not-a-real-run").status_code == 404
+
+
+def test_get_run_unknown_transaction_404():
+    assert client.get(f"/api/transcriptions/{MISSING_ID}/runs/legacy").status_code == 404
+
+
+def test_get_run_invalid_transaction_id_400():
+    assert client.get("/api/transcriptions/not-a-uuid/runs/legacy").status_code == 400
 
 
 def test_dedup_returns_latest_run_content():

--- a/apps/api/tests/test_recognition_runs.py
+++ b/apps/api/tests/test_recognition_runs.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 from conftest import client, synthesize_note, wav_bytes
 from app import storage
-from app.fingerprints import recognizer_fingerprint
+from app.fingerprints import kalimba_dsp_fingerprint, recognizer_fingerprint
 
 RUN_ID_RE = re.compile(r"^\d{8}T\d{6}\.\d{6}Z-[0-9a-z]{8}$")
 MISSING_ID = "00000000-0000-0000-0000-000000000000"
@@ -180,6 +180,64 @@ def test_review_queue_flags_stale_when_saved_fingerprint_differs():
     )
     entry = _queue_entry(tid)
     assert entry["recognizerFingerprint"] == "deadbeefcafef00d"
+    assert entry["isStale"] is True
+
+
+def test_review_queue_flags_stale_when_only_dsp_fingerprint_differs():
+    """#209 review: a kalimba_dsp-only change leaves recognizer_fingerprint()
+    unchanged (it hashes the Python sources) yet still alters output, so isStale
+    keys off a recognizer+dsp composite, not the recognizer alone."""
+    tid = _create_transaction()
+    current_fp = recognizer_fingerprint()
+    current_dsp = kalimba_dsp_fingerprint()
+
+    # recognizer matches AND dsp matches → fresh.
+    storage.create_run(
+        tid, {"events": []}, None,
+        commit_sha=None, recognizer_fingerprint=current_fp, dsp_fingerprint=current_dsp,
+    )
+    assert _queue_entry(tid)["isStale"] is False
+
+    # recognizer still matches but dsp differs → stale (the gap this fixes).
+    storage.create_run(
+        tid, {"events": []}, None,
+        commit_sha=None, recognizer_fingerprint=current_fp, dsp_fingerprint="deadbeefdsp00000",
+    )
+    assert _queue_entry(tid)["isStale"] is True
+
+    # recognizer matches, dsp unknown (run predating dsp fingerprints) → do not
+    # fabricate staleness: fresh.
+    storage.create_run(
+        tid, {"events": []}, None,
+        commit_sha=None, recognizer_fingerprint=current_fp, dsp_fingerprint=None,
+    )
+    assert _queue_entry(tid)["isStale"] is False
+
+
+def test_review_queue_fingerprint_resolves_from_readable_run():
+    """#209 review: when the newest run's response.json exists but is unreadable,
+    display resolution falls back to the previous good run — and the flagged
+    fingerprint must come from that same readable run, not the corrupt newest one
+    (else a half-written current-fingerprint run makes an older shown response
+    look fresh)."""
+    tid = _create_transaction()
+    # Older, readable run recorded with a stale recognizer fingerprint.
+    storage.create_run(
+        tid, {"events": []}, None,
+        commit_sha=None, recognizer_fingerprint="0ldfp0000stale00", dsp_fingerprint=None,
+    )
+    # Newest run: meta claims the current fingerprint, but its response.json is
+    # corrupt, so the shown response must skip it for the older good run.
+    newest = storage.create_run(
+        tid, {"events": []}, None,
+        commit_sha=None, recognizer_fingerprint=recognizer_fingerprint(), dsp_fingerprint=None,
+    )
+    (storage.get_runs_dir(tid) / newest["runId"] / "response.json").write_text(
+        "{ not valid json", encoding="utf-8"
+    )
+
+    entry = _queue_entry(tid)
+    assert entry["recognizerFingerprint"] == "0ldfp0000stale00"
     assert entry["isStale"] is True
 
 

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-import { mockTranscriptionApi } from "./fixtures/reviewMock";
+import { mockTranscriptionApi, transcription } from "./fixtures/reviewMock";
 
 test("browser-only WASM demo page renders", async ({ page }) => {
   await page.goto("/wasm-demo");
@@ -171,4 +171,74 @@ test("saved corrections survive re-transcription onset shifts (round-trip)", asy
   await expect(page.getByText("削除済")).toHaveCount(0);
   // 復元直後は保存済み状態と等価 (dirty ではない) — 保存ボタンは無効のまま
   await expect(page.getByRole("button", { name: "修正を保存" })).toBeDisabled();
+});
+
+test("editor preserves the corrections base run on save (does not rebase to latest)", async ({ page }) => {
+  // #209 review (P1): 再認識で latest が run-new になっていても、既存 corrections は
+  // その base run (run-old) に対する diff。editor はその base run をロードして編集し、
+  // 保存 baseRunId を latest に silently 書き換えない (provenance を保全)。
+  await mockTranscriptionApi(page);
+  await page.route("**/api/transcriptions/tx-e2e/runs", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        runs: [
+          { runId: "run-new-1234", isLegacy: false, eventCount: 1 },
+          { runId: "run-old-5678", isLegacy: false, eventCount: 1 },
+        ],
+        latestRunId: "run-new-1234",
+      }),
+    });
+  });
+  // corrections の base run (run-old) の全文。editor はこれを編集ベースにする。
+  await page.route("**/api/transcriptions/tx-e2e/runs/run-old-5678", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(transcription),
+    });
+  });
+  await page.route("**/api/transcriptions/tx-e2e/corrections", async (route) => {
+    if (route.request().method() === "PUT") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ corrections: route.request().postDataJSON() }),
+      });
+      return;
+    }
+    // GET: run-old に対して保存された修正 (baseRunId = run-old-5678)
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        corrections: {
+          version: 1,
+          baseRunId: "run-old-5678",
+          events: [{ timeSec: 0, notes: ["C4", "E4"], origin: "edited" }],
+        },
+      }),
+    });
+  });
+
+  await page.goto("/score/tx-e2e/review");
+  await expect(page.getByRole("heading", { name: "確認と修正" })).toBeVisible();
+
+  // dirty にするための編集 (FP 削除) → 保存。
+  await page.getByRole("button", { name: /0\.00s/ }).click();
+  await page.getByRole("button", { name: "このイベントを削除" }).click();
+  const saveBtn = page.getByRole("button", { name: "修正を保存" });
+  await expect(saveBtn).toBeEnabled();
+  const [saveReq] = await Promise.all([
+    page.waitForRequest(
+      (r) => r.url().includes("/tx-e2e/corrections") && r.method() === "PUT",
+    ),
+    saveBtn.click(),
+  ]);
+
+  // P1: 保存 payload の baseRunId は corrections の base run のまま。latest(run-new)に
+  // rebase されない。
+  const body = saveReq.postDataJSON();
+  expect(body.baseRunId).toBe("run-old-5678");
 });

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1599,6 +1599,59 @@ button:disabled {
   color: var(--danger);
 }
 
+/* #204 Phase 2: 認識履歴 (recognition runs) の切替 + 再認識 */
+.score-viewer-runs {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 14px;
+  border-radius: 12px;
+  background: var(--bg-alt);
+  border: 1px solid var(--line);
+  margin: 10px 0;
+}
+
+.score-viewer-runs-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.score-viewer-runs-select {
+  flex: 1 1 220px;
+  min-width: 0;
+  padding: 8px 10px;
+  font-size: 0.88rem;
+  border-radius: 10px;
+  border: 1px solid var(--line);
+  background: white;
+}
+
+.score-viewer-rerun-btn {
+  padding: 8px 14px;
+  font-size: 0.88rem;
+  border-radius: 10px;
+  background: var(--accent);
+  color: white;
+  border: 1px solid var(--accent-strong);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.score-viewer-rerun-btn:not(:disabled):hover {
+  background: var(--accent-strong);
+}
+
+.score-viewer-rerun-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.score-viewer-run-note {
+  margin: 0;
+}
+
 .score-viewer-share-row {
   display: flex;
   gap: 8px;
@@ -1932,6 +1985,12 @@ button:disabled {
 .review-queue-flag.warn {
   border-color: #c08a00;
   color: #8a6300;
+}
+
+/* #204 Phase 2: 保存済み response が現行 recognizer と異なるバージョンの目印 */
+.review-queue-flag.stale {
+  border-color: #2a6bc0;
+  color: #1f5aa8;
 }
 
 .simple-home-recent-head {

--- a/apps/web/src/components/ReviewEditor.tsx
+++ b/apps/web/src/components/ReviewEditor.tsx
@@ -116,19 +116,22 @@ export function ReviewEditor({ transactionId }: { transactionId: string }) {
         ]);
         if (cancelled) return;
         const latestRunId = runs?.latestRunId ?? null;
-        // #209 review (P1): 既存 corrections はその baseRunId の run に対する diff。
+        // #209 review (P1): 明示 baseRunId を持つ corrections はその run に対する diff。
         // これを latest に rematch して baseRunId=latest で保存し直すと、再認識後は
         // 人手修正の provenance/内容が silently 別 run へ rebase されてしまう。
-        // → 既存 corrections があるときはその base run (baseRunId、無ければ元 response
-        // = "legacy") の payload を編集ベースにし、保存 baseRunId もそれを維持する。
-        // 新規修正 (corrections 無し) は従来どおり latest run を対象にする。
+        // → 明示 baseRunId があるときはその run の payload を編集ベースにし、保存
+        // baseRunId もそれを維持する。
+        // baseRunId 無しの corrections (新規、または Phase 3 以前の保存) は従来どおり
+        // latest run を編集ベースにする。無しを "legacy" と決めつけない (#209 review
+        // @128: Phase 1 期に再認識済み録音へ付けた修正は元 response ではなく当時の
+        // latest run に対するものなので、legacy 固定は誤った timeline へ移してしまう)。
+        const explicitBaseRunId = corrections?.baseRunId ?? null;
         let result: TranscriptionResult;
         let baseRunId: string | null;
-        if (corrections) {
-          const base = corrections.baseRunId ?? "legacy";
+        if (explicitBaseRunId) {
           try {
-            result = await fetchTranscriptionRun(transactionId, base);
-            baseRunId = base;
+            result = await fetchTranscriptionRun(transactionId, explicitBaseRunId);
+            baseRunId = explicitBaseRunId;
           } catch {
             // base run が取得できない稀なケースは latest に fallback (latest 扱い)。
             result = await fetchTranscription(transactionId);

--- a/apps/web/src/components/ReviewEditor.tsx
+++ b/apps/web/src/components/ReviewEditor.tsx
@@ -129,14 +129,11 @@ export function ReviewEditor({ transactionId }: { transactionId: string }) {
         let result: TranscriptionResult;
         let baseRunId: string | null;
         if (explicitBaseRunId) {
-          try {
-            result = await fetchTranscriptionRun(transactionId, explicitBaseRunId);
-            baseRunId = explicitBaseRunId;
-          } catch {
-            // base run が取得できない稀なケースは latest に fallback (latest 扱い)。
-            result = await fetchTranscription(transactionId);
-            baseRunId = latestRunId;
-          }
+          // 明示 base は当該 run でしか安全に編集できない。取得失敗時に latest へ
+          // fallback すると別 timeline への rebase になるため、fallback せず上位 catch の
+          // エラー表示に委ねる (#209 review @138: provenance を書き換えない)。
+          result = await fetchTranscriptionRun(transactionId, explicitBaseRunId);
+          baseRunId = explicitBaseRunId;
         } else {
           result = await fetchTranscription(transactionId);
           baseRunId = latestRunId;

--- a/apps/web/src/components/ReviewEditor.tsx
+++ b/apps/web/src/components/ReviewEditor.tsx
@@ -16,6 +16,7 @@ import {
   fetchCorrections,
   fetchTranscription,
   fetchTranscriptionAudioBlob,
+  fetchTranscriptionRun,
   fetchTranscriptionRuns,
   fetchReviewStatus,
   saveCorrections,
@@ -107,13 +108,36 @@ export function ReviewEditor({ transactionId }: { transactionId: string }) {
         // 失敗時はページ全体をエラー表示にする (404 は api.ts 側で null になる)。
         // runs 取得の失敗は致命的ではない (#204 Phase 3 の baseRunId 記録が
         // 欠けるだけ) なので null にフォールバックする。
-        const [result, audioBlob, corrections, reviewStatus, runs] = await Promise.all([
-          fetchTranscription(transactionId),
+        const [audioBlob, corrections, reviewStatus, runs] = await Promise.all([
           fetchTranscriptionAudioBlob(transactionId),
           fetchCorrections(transactionId),
           fetchReviewStatus(transactionId).catch(() => null),
           fetchTranscriptionRuns(transactionId).catch(() => null),
         ]);
+        if (cancelled) return;
+        const latestRunId = runs?.latestRunId ?? null;
+        // #209 review (P1): 既存 corrections はその baseRunId の run に対する diff。
+        // これを latest に rematch して baseRunId=latest で保存し直すと、再認識後は
+        // 人手修正の provenance/内容が silently 別 run へ rebase されてしまう。
+        // → 既存 corrections があるときはその base run (baseRunId、無ければ元 response
+        // = "legacy") の payload を編集ベースにし、保存 baseRunId もそれを維持する。
+        // 新規修正 (corrections 無し) は従来どおり latest run を対象にする。
+        let result: TranscriptionResult;
+        let baseRunId: string | null;
+        if (corrections) {
+          const base = corrections.baseRunId ?? "legacy";
+          try {
+            result = await fetchTranscriptionRun(transactionId, base);
+            baseRunId = base;
+          } catch {
+            // base run が取得できない稀なケースは latest に fallback (latest 扱い)。
+            result = await fetchTranscription(transactionId);
+            baseRunId = latestRunId;
+          }
+        } else {
+          result = await fetchTranscription(transactionId);
+          baseRunId = latestRunId;
+        }
         if (cancelled) return;
         objectUrl = URL.createObjectURL(audioBlob);
         // 静音録音の試聴ブースト量算出用 (失敗しても主導線は妨げない)
@@ -126,9 +150,7 @@ export function ReviewEditor({ transactionId }: { transactionId: string }) {
           corrections,
           reviewStatus,
           peakDb: levels?.peakDb ?? null,
-          // fetchTranscription は常に最新 run (無ければ legacy) を返すので、
-          // ここで編集しているのはこの run に対する内容 (#204 Phase 3)。
-          baseRunId: runs?.latestRunId ?? null,
+          baseRunId,
         });
       } catch (err) {
         if (cancelled) return;

--- a/apps/web/src/components/ReviewEditor.tsx
+++ b/apps/web/src/components/ReviewEditor.tsx
@@ -16,6 +16,7 @@ import {
   fetchCorrections,
   fetchTranscription,
   fetchTranscriptionAudioBlob,
+  fetchTranscriptionRuns,
   fetchReviewStatus,
   saveCorrections,
 } from "@/lib/api";
@@ -88,6 +89,7 @@ type LoadState =
       corrections: CorrectionsPayload | null;
       reviewStatus: ReviewStatusPayload | null;
       peakDb: number | null;
+      baseRunId: string | null;
     }
   | { kind: "error"; message: string };
 
@@ -103,11 +105,14 @@ export function ReviewEditor({ transactionId }: { transactionId: string }) {
         // fetchCorrections の失敗を握りつぶさない: 保存済み修正が見えないまま
         // baseline で開くと、次の保存で既存修正を上書きしてしまう。
         // 失敗時はページ全体をエラー表示にする (404 は api.ts 側で null になる)。
-        const [result, audioBlob, corrections, reviewStatus] = await Promise.all([
+        // runs 取得の失敗は致命的ではない (#204 Phase 3 の baseRunId 記録が
+        // 欠けるだけ) なので null にフォールバックする。
+        const [result, audioBlob, corrections, reviewStatus, runs] = await Promise.all([
           fetchTranscription(transactionId),
           fetchTranscriptionAudioBlob(transactionId),
           fetchCorrections(transactionId),
           fetchReviewStatus(transactionId).catch(() => null),
+          fetchTranscriptionRuns(transactionId).catch(() => null),
         ]);
         if (cancelled) return;
         objectUrl = URL.createObjectURL(audioBlob);
@@ -121,6 +126,9 @@ export function ReviewEditor({ transactionId }: { transactionId: string }) {
           corrections,
           reviewStatus,
           peakDb: levels?.peakDb ?? null,
+          // fetchTranscription は常に最新 run (無ければ legacy) を返すので、
+          // ここで編集しているのはこの run に対する内容 (#204 Phase 3)。
+          baseRunId: runs?.latestRunId ?? null,
         });
       } catch (err) {
         if (cancelled) return;
@@ -165,6 +173,7 @@ export function ReviewEditor({ transactionId }: { transactionId: string }) {
       initialCorrections={state.corrections}
       initialReviewStatus={state.reviewStatus}
       peakDb={state.peakDb}
+      baseRunId={state.baseRunId}
     />
   );
 }
@@ -176,6 +185,7 @@ type ReadyProps = {
   initialCorrections: CorrectionsPayload | null;
   initialReviewStatus: ReviewStatusPayload | null;
   peakDb: number | null;
+  baseRunId: string | null;
 };
 
 type TimelineItem =
@@ -197,6 +207,7 @@ function ReviewEditorReady({
   initialCorrections,
   initialReviewStatus,
   peakDb,
+  baseRunId,
 }: ReadyProps) {
   const [editHistory, setEditHistory] = useState<EditHistory>(() => ({
     past: [],
@@ -331,13 +342,15 @@ function ReviewEditorReady({
   const handleSave = useCallback(async () => {
     setSaveState("saving");
     try {
-      await saveCorrections(transactionId, payload);
+      // baseRunId は保存時にのみ付与する (dirty 判定用の payload/payloadJson には
+      // 含めない — 内容が同じなら「読み込み時の run」だけで dirty 扱いにしないため)。
+      await saveCorrections(transactionId, { ...payload, baseRunId });
       lastSavedRef.current = payloadJson;
       setSaveState("saved");
     } catch {
       setSaveState("error");
     }
-  }, [transactionId, payload, payloadJson]);
+  }, [transactionId, payload, payloadJson, baseRunId]);
 
   const visibleEvents = useMemo(() => activeEvents(reviewState), [reviewState]);
 

--- a/apps/web/src/components/ReviewQueue.tsx
+++ b/apps/web/src/components/ReviewQueue.tsx
@@ -209,6 +209,14 @@ export function ReviewQueue() {
                         候補 {entry.candidateSlotCount}
                       </span>
                     ) : null}
+                    {entry.isStale ? (
+                      <span
+                        className="review-queue-flag stale"
+                        title="保存されている認識結果は現在の認識器と異なるバージョンです。再認識で最新化できます。"
+                      >
+                        更新あり
+                      </span>
+                    ) : null}
                   </span>
                 </Link>
               </li>

--- a/apps/web/src/components/ScoreViewer.tsx
+++ b/apps/web/src/components/ScoreViewer.tsx
@@ -106,24 +106,30 @@ export function ScoreViewer({ transactionId }: { transactionId: string }) {
         let correctionsBaseRunId: string | null = null;
         if (corrections && corrections.events.length > 0) {
           const explicitBase = corrections.baseRunId ?? null;
-          let baseResult = result; // 既定は latest (表示中の解決済み result)
+          // 既定は latest (表示中の解決済み result)。明示 base があればその run を取得。
+          // 取得失敗時は latest に rematch せず null にして corrected を出さない
+          // (#209 review @114: 誤 run に整列した corrected の表示/export を防ぐ。
+          // editor 側 @138 と同じ「別 timeline に寄せない」原則)。
+          let baseResult: TranscriptionResult | null = result;
           if (explicitBase && explicitBase !== runs.latestRunId) {
             try {
               baseResult = await fetchTranscriptionRun(transactionId, explicitBase);
             } catch {
-              baseResult = result; // base run が取れないときは latest に best-effort
+              baseResult = null;
             }
             if (cancelled) return;
           }
-          try {
-            correctedEvents = toDisplayScoreEvents(
-              restoreStateFromCorrections(baseResult, corrections),
-            );
-            // 明示 base があればその run、無ければ latest (null = runs 不明時)。
-            correctionsBaseRunId = explicitBase ?? runs.latestRunId ?? null;
-          } catch {
-            correctedEvents = null;
-            correctionsBaseRunId = null;
+          if (baseResult) {
+            try {
+              correctedEvents = toDisplayScoreEvents(
+                restoreStateFromCorrections(baseResult, corrections),
+              );
+              // 明示 base があればその run、無ければ latest (null = runs 不明時)。
+              correctionsBaseRunId = explicitBase ?? runs.latestRunId ?? null;
+            } catch {
+              correctedEvents = null;
+              correctionsBaseRunId = null;
+            }
           }
         }
         setState({
@@ -332,9 +338,11 @@ function ScoreViewerReady({
   // 「最新」= runsState.latestRunId を指す)。別 run を閲覧中は無言で消さず note で
   // base run へ誘導する。これで再認識後に誤整列した corrected を表示しない。
   const normalizedSelectedRunId = selectedRunId ?? runsState.latestRunId;
-  // 明示 base が無い corrections (correctionsBaseRunId=null) は latest に対するものと
-  // みなす (#202)。runs 不明時は latestRunId も null になり、既定選択も null なので一致する。
-  const effectiveCorrectionsRun = correctionsBaseRunId ?? runsState.latestRunId;
+  // 明示 base が無い corrections (correctionsBaseRunId=null) は「読み込み時の latest」に
+  // 対して算出済み。mutable な runsState.latestRunId ではなく安定な initialRuns.latestRunId
+  // に pin する — こうしないと再認識で latest が変わったとき null-base corrected が新 run へ
+  // float してしまう (#209 review @337)。runs 不明時は両者 null で一致する。
+  const effectiveCorrectionsRun = correctionsBaseRunId ?? initialRuns.latestRunId;
   const isViewingCorrectionsBase =
     correctedEvents !== null && normalizedSelectedRunId === effectiveCorrectionsRun;
   const [viewSource, setViewSource] = useState<"corrected" | "recognized">(

--- a/apps/web/src/components/ScoreViewer.tsx
+++ b/apps/web/src/components/ScoreViewer.tsx
@@ -187,6 +187,15 @@ function ScoreViewerReady({
   // それ以外を選ぶと GET .../runs/{runId} で該当 run の全文を取得して表示する。
   const [runsState, setRunsState] = useState<RecognitionRunsResponse>(initialRuns);
   const [selectedRunId, setSelectedRunId] = useState<string | null>(initialRuns.latestRunId);
+  // "最新" の内容そのもの。load() が返した latestResult prop で初期化するが、
+  // 再認識 (handleRerun) が起きるとその新しい run が「最新」になるので更新する。
+  // これを latestResult prop 自体で代用すると (#204 Phase 2 の実装バグとして
+  // 発見): 再認識直後は selectedRunId/runsState.latestRunId が新しい runId に
+  // 揃うため isViewingLatestRun が true に戻り、下の effect が「最新に戻す」
+  // 分岐を実行する。その時 latestResult (初回読み込み時点の古いスナップショット)
+  // へreset してしまうと、再認識で表示したはずの新しい結果が即座に古い結果へ
+  // 巻き戻ってしまう。
+  const [latestKnownResult, setLatestKnownResult] = useState<TranscriptionResult>(latestResult);
   const [displayResult, setDisplayResult] = useState<TranscriptionResult>(latestResult);
   const [runSwitchBusy, setRunSwitchBusy] = useState(false);
   const [runSwitchError, setRunSwitchError] = useState<string | null>(null);
@@ -196,7 +205,7 @@ function ScoreViewerReady({
 
   useEffect(() => {
     if (isViewingLatestRun) {
-      setDisplayResult(latestResult);
+      setDisplayResult(latestKnownResult);
       setRunSwitchError(null);
       return;
     }
@@ -221,7 +230,7 @@ function ScoreViewerReady({
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedRunId, isViewingLatestRun, transactionId]);
+  }, [selectedRunId, isViewingLatestRun, transactionId, latestKnownResult]);
 
   const handleRerun = useCallback(async () => {
     setRerunBusy(true);
@@ -230,6 +239,7 @@ function ScoreViewerReady({
       const created = await createTranscriptionRun(transactionId);
       const refreshed = await fetchTranscriptionRuns(transactionId);
       setRunsState(refreshed);
+      setLatestKnownResult(created.result);
       setSelectedRunId(created.runId);
       setDisplayResult(created.result);
     } catch (err) {
@@ -262,13 +272,16 @@ function ScoreViewerReady({
   );
 
   // #202: 修正済み版があれば既定でそれを表示。認識結果へは切替可能。
-  // correctedEvents は読み込み時の最新 run に対して算出されたものなので
-  // (#204 Phase 2)、それ以外の過去 run を閲覧中は認識結果 (その run の生の
-  // events) を表示する — 過去 run に対する修正差分の整列は Phase 3 未対応。
+  // correctedEvents は読み込み時の run (initialRuns.latestRunId) に対して
+  // 算出されたものなので (#204 Phase 2)、過去 run を閲覧中はもちろん、
+  // 再認識で「最新」が別の run に変わった後もそのままでは整列が保証できない
+  // (再認識後は isViewingLatestRun は true に戻るが、それは新しい run に
+  // 対して) — なので「読み込み時と同じ run を見ているか」で厳密にゲートする。
+  const isViewingOriginalRun = selectedRunId === initialRuns.latestRunId;
   const [viewSource, setViewSource] = useState<"corrected" | "recognized">(
     correctedEvents ? "corrected" : "recognized",
   );
-  const showCorrectedToggle = isViewingLatestRun && Boolean(correctedEvents);
+  const showCorrectedToggle = isViewingOriginalRun && Boolean(correctedEvents);
   const events =
     showCorrectedToggle && viewSource === "corrected" && correctedEvents
       ? correctedEvents
@@ -410,9 +423,9 @@ function ScoreViewerReady({
               {viewSource === "corrected" ? "認識結果を表示" : "修正済み版を表示"}
             </button>
           </div>
-        ) : !isViewingLatestRun ? (
+        ) : !isViewingOriginalRun && correctedEvents ? (
           <p className="muted score-viewer-run-note">
-            過去の認識結果を表示中です (修正済み版との切替は最新の認識結果でのみ利用できます)。
+            この認識結果は修正済み版の算出元とは異なります (修正済み版との切替は元の認識結果でのみ利用できます)。
           </p>
         ) : null}
         <div className="score-viewer-mode-toggle" role="group" aria-label="ドレミ表記">

--- a/apps/web/src/components/ScoreViewer.tsx
+++ b/apps/web/src/components/ScoreViewer.tsx
@@ -98,16 +98,18 @@ export function ScoreViewer({ transactionId }: { transactionId: string }) {
         // #202 / #209 review: corrections が保存済みなら編集後イベント列を導出する。
         // corrections はその base run に対する diff。明示 baseRunId があればその run の
         // payload に restore する (latest に rematch すると再認識後に誤整列した corrected
-        // を表示してしまう)。baseRunId 無しの corrections は "legacy" と決めつけず latest
-        // に対するものとみなす (#209 review @128、#202 の既定挙動を踏襲・no-regression)。
+        // を表示してしまう)。明示 baseRunId 無しの corrections は latest (= 表示中の
+        // 解決済み result) に対するものとみなす (#202 の既定挙動を踏襲・no-regression)。
+        // runs が取得できなくても (latestRunId=null) corrections は表示する — restore は
+        // result に対して行えるため、runs 不在で corrected を落とさない (#209 review @105)。
         let correctedEvents: ScoreEvent[] | null = null;
         let correctionsBaseRunId: string | null = null;
-        if (corrections && corrections.events.length > 0 && runs.latestRunId) {
-          correctionsBaseRunId = corrections.baseRunId ?? runs.latestRunId;
-          let baseResult = result; // base===latest の一般ケースは latest を再利用
-          if (correctionsBaseRunId !== runs.latestRunId) {
+        if (corrections && corrections.events.length > 0) {
+          const explicitBase = corrections.baseRunId ?? null;
+          let baseResult = result; // 既定は latest (表示中の解決済み result)
+          if (explicitBase && explicitBase !== runs.latestRunId) {
             try {
-              baseResult = await fetchTranscriptionRun(transactionId, correctionsBaseRunId);
+              baseResult = await fetchTranscriptionRun(transactionId, explicitBase);
             } catch {
               baseResult = result; // base run が取れないときは latest に best-effort
             }
@@ -117,6 +119,8 @@ export function ScoreViewer({ transactionId }: { transactionId: string }) {
             correctedEvents = toDisplayScoreEvents(
               restoreStateFromCorrections(baseResult, corrections),
             );
+            // 明示 base があればその run、無ければ latest (null = runs 不明時)。
+            correctionsBaseRunId = explicitBase ?? runs.latestRunId ?? null;
           } catch {
             correctedEvents = null;
             correctionsBaseRunId = null;
@@ -328,8 +332,11 @@ function ScoreViewerReady({
   // 「最新」= runsState.latestRunId を指す)。別 run を閲覧中は無言で消さず note で
   // base run へ誘導する。これで再認識後に誤整列した corrected を表示しない。
   const normalizedSelectedRunId = selectedRunId ?? runsState.latestRunId;
+  // 明示 base が無い corrections (correctionsBaseRunId=null) は latest に対するものと
+  // みなす (#202)。runs 不明時は latestRunId も null になり、既定選択も null なので一致する。
+  const effectiveCorrectionsRun = correctionsBaseRunId ?? runsState.latestRunId;
   const isViewingCorrectionsBase =
-    correctionsBaseRunId !== null && normalizedSelectedRunId === correctionsBaseRunId;
+    correctedEvents !== null && normalizedSelectedRunId === effectiveCorrectionsRun;
   const [viewSource, setViewSource] = useState<"corrected" | "recognized">(
     correctedEvents ? "corrected" : "recognized",
   );

--- a/apps/web/src/components/ScoreViewer.tsx
+++ b/apps/web/src/components/ScoreViewer.tsx
@@ -95,16 +95,31 @@ export function ScoreViewer({ transactionId }: { transactionId: string }) {
         // 静音録音の試聴ブースト用 (lib/audioBoost)。失敗しても再生には影響しない
         const levels = await computeAudioLevels(audioBlob).catch(() => null);
         if (cancelled) return;
-        // #202: corrections が保存済みなら編集後イベント列を導出して既定表示に
-        // する (表記トグル / export は表示中の列に対して機能する)。
+        // #202 / #209 review: corrections が保存済みなら編集後イベント列を導出する。
+        // corrections はその baseRunId の run に対する diff なので、latest ではなく
+        // その base run の payload に restore する (latest に rematch すると再認識後に
+        // 誤整列した corrected を表示してしまう)。baseRunId 無しの旧 corrections は
+        // 元 response = "legacy" に対するものとみなす。
         let correctedEvents: ScoreEvent[] | null = null;
+        let correctionsBaseRunId: string | null = null;
         if (corrections && corrections.events.length > 0) {
+          correctionsBaseRunId = corrections.baseRunId ?? "legacy";
+          let baseResult = result; // base===latest の一般ケースは latest を再利用
+          if (correctionsBaseRunId !== runs.latestRunId) {
+            try {
+              baseResult = await fetchTranscriptionRun(transactionId, correctionsBaseRunId);
+            } catch {
+              baseResult = result; // base run が取れないときは latest に best-effort
+            }
+            if (cancelled) return;
+          }
           try {
             correctedEvents = toDisplayScoreEvents(
-              restoreStateFromCorrections(result, corrections),
+              restoreStateFromCorrections(baseResult, corrections),
             );
           } catch {
             correctedEvents = null;
+            correctionsBaseRunId = null;
           }
         }
         setState({
@@ -113,9 +128,9 @@ export function ScoreViewer({ transactionId }: { transactionId: string }) {
           audioUrl: objectUrl,
           initialMemo: memo,
           correctedEvents,
-          // #209 review: どの run に対して保存された corrections かを保持し、
-          // corrected トグルを「その run を見ているときだけ」に厳密化する材料にする。
-          correctionsBaseRunId: corrections?.baseRunId ?? null,
+          // #209 review: corrections がどの run に対するものかを保持し、その run を
+          // 閲覧しているときだけ corrected を出す (別 run 閲覧時は note で誘導)。
+          correctionsBaseRunId,
           peakDb: levels?.peakDb ?? null,
           runs,
         });
@@ -197,7 +212,11 @@ function ScoreViewerReady({
   // (または runs が空) のときは load() が返した最新解決結果をそのまま使う。
   // それ以外を選ぶと GET .../runs/{runId} で該当 run の全文を取得して表示する。
   const [runsState, setRunsState] = useState<RecognitionRunsResponse>(initialRuns);
-  const [selectedRunId, setSelectedRunId] = useState<string | null>(initialRuns.latestRunId);
+  // #209 review: corrections があれば既定でその base run を選択して corrected を
+  // 既定表示する (#202「修正済みを既定表示」を run-correct に踏襲)。無ければ latest。
+  const [selectedRunId, setSelectedRunId] = useState<string | null>(
+    correctionsBaseRunId ?? initialRuns.latestRunId,
+  );
   // "最新" の内容そのもの。load() が返した latestResult prop で初期化するが、
   // 再認識 (handleRerun) が起きるとその新しい run が「最新」になるので更新する。
   // これを latestResult prop 自体で代用すると (#204 Phase 2 の実装バグとして
@@ -304,19 +323,20 @@ function ScoreViewerReady({
   // 再認識で「最新」が別の run に変わった後もそのままでは整列が保証できない
   // (再認識後は isViewingLatestRun は true に戻るが、それは新しい run に
   // 対して) — なので「読み込み時と同じ run を見ているか」で厳密にゲートする。
-  const isViewingOriginalRun = selectedRunId === initialRuns.latestRunId;
-  // #209 review (P1): corrections が「ロード時に表示している run」以外に対して
-  // 保存されている (baseRunId が食い違う = 保存後に再認識された) 場合、それを今の
-  // run へ ±50ms で rematch した corrected 列は整列を保証できない。安全側に倒して
-  // corrected トグル自体を出さず、誤整列した corrected の表示/export を防ぐ。
-  // baseRunId が無い旧 corrections はロード時 run に対するものとみなす (従来挙動)。
-  const correctionsMatchLoadedRun =
-    correctionsBaseRunId === null || correctionsBaseRunId === initialRuns.latestRunId;
+  // #209 review: corrections はその base run に束ねる。いま選んでいる run が
+  // corrections の base run のときだけ corrected を出す (selectedRunId===null は
+  // 「最新」= runsState.latestRunId を指す)。別 run を閲覧中は無言で消さず note で
+  // base run へ誘導する。これで再認識後に誤整列した corrected を表示しない。
+  const normalizedSelectedRunId = selectedRunId ?? runsState.latestRunId;
+  const isViewingCorrectionsBase =
+    correctionsBaseRunId !== null && normalizedSelectedRunId === correctionsBaseRunId;
   const [viewSource, setViewSource] = useState<"corrected" | "recognized">(
-    correctedEvents && correctionsMatchLoadedRun ? "corrected" : "recognized",
+    correctedEvents ? "corrected" : "recognized",
   );
-  const showCorrectedToggle =
-    isViewingOriginalRun && correctionsMatchLoadedRun && Boolean(correctedEvents);
+  const showCorrectedToggle = isViewingCorrectionsBase && Boolean(correctedEvents);
+  // corrections はあるが別 run (再認識後の新 run 等) を閲覧中: 保存済み修正を
+  // 無言で消さず、base run を選べば見られる旨の note を出す (P3)。
+  const showCorrectionsElsewhereNote = Boolean(correctedEvents) && !isViewingCorrectionsBase;
   const events =
     showCorrectedToggle && viewSource === "corrected" && correctedEvents
       ? correctedEvents
@@ -458,9 +478,9 @@ function ScoreViewerReady({
               {viewSource === "corrected" ? "認識結果を表示" : "修正済み版を表示"}
             </button>
           </div>
-        ) : !isViewingOriginalRun && correctedEvents ? (
+        ) : showCorrectionsElsewhereNote ? (
           <p className="muted score-viewer-run-note">
-            この認識結果は修正済み版の算出元とは異なります (修正済み版との切替は元の認識結果でのみ利用できます)。
+            この録音には別の認識結果に対して保存された修正版があります。上の履歴からその認識結果を選ぶと修正版を表示・切替できます。
           </p>
         ) : null}
         <div className="score-viewer-mode-toggle" role="group" aria-label="ドレミ表記">

--- a/apps/web/src/components/ScoreViewer.tsx
+++ b/apps/web/src/components/ScoreViewer.tsx
@@ -17,10 +17,13 @@ import {
 } from "@/lib/audioBoost";
 import { computeAudioLevels } from "@/lib/audio";
 import {
+  createTranscriptionRun,
   createTranscriptionWithCapture,
   fetchMemo,
   fetchTranscription,
   fetchTranscriptionAudioBlob,
+  fetchTranscriptionRun,
+  fetchTranscriptionRuns,
   fetchTunings,
   fetchCorrections,
   saveMemo,
@@ -35,7 +38,16 @@ import {
   tonicReferenceOctave,
 } from "@/lib/scoreLayout";
 import { restoreStateFromCorrections, toDisplayScoreEvents } from "@/lib/reviewCorrections";
-import { InstrumentTuning, ScoreEvent, TranscriptionResult, TuningMismatch } from "@/lib/types";
+import {
+  InstrumentTuning,
+  RecognitionRun,
+  RecognitionRunsResponse,
+  ScoreEvent,
+  TranscriptionResult,
+  TuningMismatch,
+} from "@/lib/types";
+
+const EMPTY_RUNS: RecognitionRunsResponse = { runs: [], latestRunId: null };
 
 type LabelMode = "fixed" | "movable" | "movableNumber";
 const LABEL_MODE_STORAGE_KEY = "kalimba:score-label-mode";
@@ -53,6 +65,7 @@ type LoadState =
       initialMemo: string;
       correctedEvents: ScoreEvent[] | null;
       peakDb: number | null;
+      runs: RecognitionRunsResponse;
     }
   | { kind: "error"; message: string };
 
@@ -67,11 +80,14 @@ export function ScoreViewer({ transactionId }: { transactionId: string }) {
 
     async function load() {
       try {
-        const [result, audioBlob, memo, corrections] = await Promise.all([
+        // runs の取得失敗は致命的ではない (#204 Phase 2 の run 切替 UI が
+        // 出せないだけ) なので空扱いにフォールバックする。
+        const [result, audioBlob, memo, corrections, runs] = await Promise.all([
           fetchTranscription(transactionId),
           fetchTranscriptionAudioBlob(transactionId),
           fetchMemo(transactionId).catch(() => ""),
           fetchCorrections(transactionId).catch(() => null),
+          fetchTranscriptionRuns(transactionId).catch(() => EMPTY_RUNS),
         ]);
         if (cancelled) return;
         objectUrl = URL.createObjectURL(audioBlob);
@@ -97,6 +113,7 @@ export function ScoreViewer({ transactionId }: { transactionId: string }) {
           initialMemo: memo,
           correctedEvents,
           peakDb: levels?.peakDb ?? null,
+          runs,
         });
       } catch (err) {
         if (cancelled) return;
@@ -138,6 +155,7 @@ export function ScoreViewer({ transactionId }: { transactionId: string }) {
       initialMemo={state.initialMemo}
       correctedEvents={state.correctedEvents}
       peakDb={state.peakDb}
+      initialRuns={state.runs}
     />
   );
 }
@@ -149,11 +167,82 @@ type ReadyProps = {
   initialMemo: string;
   correctedEvents: ScoreEvent[] | null;
   peakDb: number | null;
+  initialRuns: RecognitionRunsResponse;
 };
 
-function ScoreViewerReady({ transactionId, result, audioUrl, initialMemo, correctedEvents, peakDb }: ReadyProps) {
+function ScoreViewerReady({
+  transactionId,
+  result: latestResult,
+  audioUrl,
+  initialMemo,
+  correctedEvents,
+  peakDb,
+  initialRuns,
+}: ReadyProps) {
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const [activeEventId, setActiveEventId] = useState<string | null>(null);
+
+  // #204 Phase 2: 認識履歴 (recognition runs) の切替。selectedRunId が最新 run
+  // (または runs が空) のときは load() が返した最新解決結果をそのまま使う。
+  // それ以外を選ぶと GET .../runs/{runId} で該当 run の全文を取得して表示する。
+  const [runsState, setRunsState] = useState<RecognitionRunsResponse>(initialRuns);
+  const [selectedRunId, setSelectedRunId] = useState<string | null>(initialRuns.latestRunId);
+  const [displayResult, setDisplayResult] = useState<TranscriptionResult>(latestResult);
+  const [runSwitchBusy, setRunSwitchBusy] = useState(false);
+  const [runSwitchError, setRunSwitchError] = useState<string | null>(null);
+  const [rerunBusy, setRerunBusy] = useState(false);
+  const [rerunError, setRerunError] = useState<string | null>(null);
+  const isViewingLatestRun = selectedRunId === null || selectedRunId === runsState.latestRunId;
+
+  useEffect(() => {
+    if (isViewingLatestRun) {
+      setDisplayResult(latestResult);
+      setRunSwitchError(null);
+      return;
+    }
+    let cancelled = false;
+    setRunSwitchBusy(true);
+    setRunSwitchError(null);
+    fetchTranscriptionRun(transactionId, selectedRunId as string)
+      .then((run) => {
+        if (cancelled) return;
+        setDisplayResult(run);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setRunSwitchError(
+          err instanceof Error ? err.message : "この認識結果の読み込みに失敗しました。",
+        );
+      })
+      .finally(() => {
+        if (!cancelled) setRunSwitchBusy(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedRunId, isViewingLatestRun, transactionId]);
+
+  const handleRerun = useCallback(async () => {
+    setRerunBusy(true);
+    setRerunError(null);
+    try {
+      const created = await createTranscriptionRun(transactionId);
+      const refreshed = await fetchTranscriptionRuns(transactionId);
+      setRunsState(refreshed);
+      setSelectedRunId(created.runId);
+      setDisplayResult(created.result);
+    } catch (err) {
+      setRerunError(err instanceof Error ? err.message : "再認識に失敗しました。");
+    } finally {
+      setRerunBusy(false);
+    }
+  }, [transactionId]);
+
+  // ダウンストリームの表示ロジック (labelMode / events / warnings / export 等)
+  // は全て「今表示している認識結果」に対して働けばよいので、result という名前を
+  // ここでシャドウする (result.xxx への既存参照をそのまま activeResult として使う)。
+  const result = displayResult;
 
   // 静音録音のブースト + 片チャンネル無音ステレオの両耳化 (lib/audioBoost)
   const boostChainRef = useRef<AudioBoostChain | null>(null);
@@ -173,10 +262,17 @@ function ScoreViewerReady({ transactionId, result, audioUrl, initialMemo, correc
   );
 
   // #202: 修正済み版があれば既定でそれを表示。認識結果へは切替可能。
+  // correctedEvents は読み込み時の最新 run に対して算出されたものなので
+  // (#204 Phase 2)、それ以外の過去 run を閲覧中は認識結果 (その run の生の
+  // events) を表示する — 過去 run に対する修正差分の整列は Phase 3 未対応。
   const [viewSource, setViewSource] = useState<"corrected" | "recognized">(
     correctedEvents ? "corrected" : "recognized",
   );
-  const events = viewSource === "corrected" && correctedEvents ? correctedEvents : result.events;
+  const showCorrectedToggle = isViewingLatestRun && Boolean(correctedEvents);
+  const events =
+    showCorrectedToggle && viewSource === "corrected" && correctedEvents
+      ? correctedEvents
+      : result.events;
 
   const allNotes = useMemo(
     () => events.flatMap((e) => e.notes),
@@ -254,6 +350,18 @@ function ScoreViewerReady({ transactionId, result, audioUrl, initialMemo, correc
         <ShareUrlRow url={shareUrl} />
       </header>
 
+      <RunHistoryPanel
+        runs={runsState.runs}
+        latestRunId={runsState.latestRunId}
+        selectedRunId={selectedRunId}
+        onSelect={setSelectedRunId}
+        switchBusy={runSwitchBusy}
+        switchError={runSwitchError}
+        onRerun={handleRerun}
+        rerunBusy={rerunBusy}
+        rerunError={rerunError}
+      />
+
       {result.tuningMismatch ? (
         <TuningMismatchBanner
           transactionId={transactionId}
@@ -289,7 +397,7 @@ function ScoreViewerReady({ transactionId, result, audioUrl, initialMemo, correc
       </section>
 
       <section className="score-viewer-score" ref={scoreAreaRef}>
-        {correctedEvents ? (
+        {showCorrectedToggle ? (
           <div className="score-viewer-source-row">
             <span className={`score-source-badge${viewSource === "corrected" ? " corrected" : ""}`}>
               {viewSource === "corrected" ? "修正済み版を表示中" : "認識結果 (未修正) を表示中"}
@@ -302,6 +410,10 @@ function ScoreViewerReady({ transactionId, result, audioUrl, initialMemo, correc
               {viewSource === "corrected" ? "認識結果を表示" : "修正済み版を表示"}
             </button>
           </div>
+        ) : !isViewingLatestRun ? (
+          <p className="muted score-viewer-run-note">
+            過去の認識結果を表示中です (修正済み版との切替は最新の認識結果でのみ利用できます)。
+          </p>
         ) : null}
         <div className="score-viewer-mode-toggle" role="group" aria-label="ドレミ表記">
           <button
@@ -517,6 +629,86 @@ function RetranscribeSection({
       {error || fetchError ? (
         <p className="score-viewer-retranscribe-error">{error ?? fetchError}</p>
       ) : null}
+    </section>
+  );
+}
+
+function formatRunTimestamp(ranAt: string | null): string {
+  if (!ranAt) return "";
+  try {
+    return new Date(ranAt).toLocaleString();
+  } catch {
+    return ranAt;
+  }
+}
+
+function formatRunLabel(run: RecognitionRun): string {
+  if (run.isLegacy) {
+    return `アップロード時点 (レガシー) · ${run.eventCount} events`;
+  }
+  const fp = run.recognizerFingerprint ? run.recognizerFingerprint.slice(0, 8) : "fp不明";
+  return `${formatRunTimestamp(run.ranAt)} · ${fp} · ${run.eventCount} events`;
+}
+
+// #204 Phase 2: 認識履歴 (runs) の切替 + 現行認識器での再認識。
+// GET .../runs で返る全 run (legacy 含む) を新しい順のまま select の選択肢にする。
+function RunHistoryPanel({
+  runs,
+  latestRunId,
+  selectedRunId,
+  onSelect,
+  switchBusy,
+  switchError,
+  onRerun,
+  rerunBusy,
+  rerunError,
+}: {
+  runs: RecognitionRun[];
+  latestRunId: string | null;
+  selectedRunId: string | null;
+  onSelect: (runId: string) => void;
+  switchBusy: boolean;
+  switchError: string | null;
+  onRerun: () => void;
+  rerunBusy: boolean;
+  rerunError: string | null;
+}) {
+  const effectiveSelected = selectedRunId ?? latestRunId ?? "";
+
+  return (
+    <section className="score-viewer-runs">
+      <div className="score-viewer-runs-row">
+        {runs.length > 0 ? (
+          <select
+            className="score-viewer-runs-select"
+            value={effectiveSelected}
+            onChange={(e) => onSelect(e.target.value)}
+            disabled={switchBusy}
+            aria-label="認識結果の履歴"
+          >
+            {runs.map((run) => (
+              <option key={run.runId} value={run.runId}>
+                {run.runId === latestRunId ? "最新 · " : ""}
+                {formatRunLabel(run)}
+              </option>
+            ))}
+          </select>
+        ) : (
+          <span className="muted">認識履歴を取得できませんでした。</span>
+        )}
+        <button
+          type="button"
+          className="score-viewer-rerun-btn"
+          onClick={onRerun}
+          disabled={rerunBusy}
+          title="保存済みの録音+調律のまま、現在の認識器で再認識して履歴に追加します (新しい transaction は作られません)"
+        >
+          {rerunBusy ? "再認識中…" : "現在の認識器で再認識"}
+        </button>
+      </div>
+      {switchBusy ? <p className="muted">読み込み中…</p> : null}
+      {switchError ? <p className="score-viewer-retranscribe-error">{switchError}</p> : null}
+      {rerunError ? <p className="score-viewer-retranscribe-error">{rerunError}</p> : null}
     </section>
   );
 }

--- a/apps/web/src/components/ScoreViewer.tsx
+++ b/apps/web/src/components/ScoreViewer.tsx
@@ -96,14 +96,14 @@ export function ScoreViewer({ transactionId }: { transactionId: string }) {
         const levels = await computeAudioLevels(audioBlob).catch(() => null);
         if (cancelled) return;
         // #202 / #209 review: corrections が保存済みなら編集後イベント列を導出する。
-        // corrections はその baseRunId の run に対する diff なので、latest ではなく
-        // その base run の payload に restore する (latest に rematch すると再認識後に
-        // 誤整列した corrected を表示してしまう)。baseRunId 無しの旧 corrections は
-        // 元 response = "legacy" に対するものとみなす。
+        // corrections はその base run に対する diff。明示 baseRunId があればその run の
+        // payload に restore する (latest に rematch すると再認識後に誤整列した corrected
+        // を表示してしまう)。baseRunId 無しの corrections は "legacy" と決めつけず latest
+        // に対するものとみなす (#209 review @128、#202 の既定挙動を踏襲・no-regression)。
         let correctedEvents: ScoreEvent[] | null = null;
         let correctionsBaseRunId: string | null = null;
-        if (corrections && corrections.events.length > 0) {
-          correctionsBaseRunId = corrections.baseRunId ?? "legacy";
+        if (corrections && corrections.events.length > 0 && runs.latestRunId) {
+          correctionsBaseRunId = corrections.baseRunId ?? runs.latestRunId;
           let baseResult = result; // base===latest の一般ケースは latest を再利用
           if (correctionsBaseRunId !== runs.latestRunId) {
             try {

--- a/apps/web/src/components/ScoreViewer.tsx
+++ b/apps/web/src/components/ScoreViewer.tsx
@@ -64,6 +64,7 @@ type LoadState =
       audioUrl: string;
       initialMemo: string;
       correctedEvents: ScoreEvent[] | null;
+      correctionsBaseRunId: string | null;
       peakDb: number | null;
       runs: RecognitionRunsResponse;
     }
@@ -112,6 +113,9 @@ export function ScoreViewer({ transactionId }: { transactionId: string }) {
           audioUrl: objectUrl,
           initialMemo: memo,
           correctedEvents,
+          // #209 review: どの run に対して保存された corrections かを保持し、
+          // corrected トグルを「その run を見ているときだけ」に厳密化する材料にする。
+          correctionsBaseRunId: corrections?.baseRunId ?? null,
           peakDb: levels?.peakDb ?? null,
           runs,
         });
@@ -148,12 +152,17 @@ export function ScoreViewer({ transactionId }: { transactionId: string }) {
   }
 
   return (
+    // key で transactionId ごとに remount させ、run 切替用の useState が前の
+    // 録音の値を持ち越さないようにする (#209 review: 同一インスタンスに別
+    // transactionId が来ても useState 初期化子は再実行されないため)。
     <ScoreViewerReady
+      key={transactionId}
       transactionId={transactionId}
       result={state.result}
       audioUrl={state.audioUrl}
       initialMemo={state.initialMemo}
       correctedEvents={state.correctedEvents}
+      correctionsBaseRunId={state.correctionsBaseRunId}
       peakDb={state.peakDb}
       initialRuns={state.runs}
     />
@@ -166,6 +175,7 @@ type ReadyProps = {
   audioUrl: string;
   initialMemo: string;
   correctedEvents: ScoreEvent[] | null;
+  correctionsBaseRunId: string | null;
   peakDb: number | null;
   initialRuns: RecognitionRunsResponse;
 };
@@ -176,6 +186,7 @@ function ScoreViewerReady({
   audioUrl,
   initialMemo,
   correctedEvents,
+  correctionsBaseRunId,
   peakDb,
   initialRuns,
 }: ReadyProps) {
@@ -207,6 +218,10 @@ function ScoreViewerReady({
     if (isViewingLatestRun) {
       setDisplayResult(latestKnownResult);
       setRunSwitchError(null);
+      // #209 review: 履歴 run の fetch 進行中に「最新」へ戻ると、前 effect の
+      // cleanup が cancelled=true にして in-flight の finally が busy 解除を
+      // skip する。この分岐でも解除しないと selector が disabled のまま固まる。
+      setRunSwitchBusy(false);
       return;
     }
     let cancelled = false;
@@ -237,11 +252,23 @@ function ScoreViewerReady({
     setRerunError(null);
     try {
       const created = await createTranscriptionRun(transactionId);
-      const refreshed = await fetchTranscriptionRuns(transactionId);
-      setRunsState(refreshed);
+      // #209 review: created は既にサーバへ append 済み。まず結果を表示に反映
+      // してから履歴一覧を更新する。こうしないと後続の fetchTranscriptionRuns が
+      // 失敗したとき「再認識は成功したのに失敗表示 → ユーザー再試行で重複 run」
+      // に陥る (runs は append-only)。
       setLatestKnownResult(created.result);
-      setSelectedRunId(created.runId);
       setDisplayResult(created.result);
+      try {
+        const refreshed = await fetchTranscriptionRuns(transactionId);
+        setRunsState(refreshed);
+        setSelectedRunId(created.runId);
+      } catch {
+        // 履歴一覧の更新だけ失敗: created は表示済み。selectedRunId=null で
+        // 「最新」扱いにして created.result を表示し続ける (dropdown は次回
+        // ロードで整合)。重複 run を生む再試行を促さない。
+        setSelectedRunId(null);
+        setRunSwitchError("再認識は成功しましたが履歴一覧の更新に失敗しました。リロードで反映されます。");
+      }
     } catch (err) {
       setRerunError(err instanceof Error ? err.message : "再認識に失敗しました。");
     } finally {
@@ -278,10 +305,18 @@ function ScoreViewerReady({
   // (再認識後は isViewingLatestRun は true に戻るが、それは新しい run に
   // 対して) — なので「読み込み時と同じ run を見ているか」で厳密にゲートする。
   const isViewingOriginalRun = selectedRunId === initialRuns.latestRunId;
+  // #209 review (P1): corrections が「ロード時に表示している run」以外に対して
+  // 保存されている (baseRunId が食い違う = 保存後に再認識された) 場合、それを今の
+  // run へ ±50ms で rematch した corrected 列は整列を保証できない。安全側に倒して
+  // corrected トグル自体を出さず、誤整列した corrected の表示/export を防ぐ。
+  // baseRunId が無い旧 corrections はロード時 run に対するものとみなす (従来挙動)。
+  const correctionsMatchLoadedRun =
+    correctionsBaseRunId === null || correctionsBaseRunId === initialRuns.latestRunId;
   const [viewSource, setViewSource] = useState<"corrected" | "recognized">(
-    correctedEvents ? "corrected" : "recognized",
+    correctedEvents && correctionsMatchLoadedRun ? "corrected" : "recognized",
   );
-  const showCorrectedToggle = isViewingOriginalRun && Boolean(correctedEvents);
+  const showCorrectedToggle =
+    isViewingOriginalRun && correctionsMatchLoadedRun && Boolean(correctedEvents);
   const events =
     showCorrectedToggle && viewSource === "corrected" && correctedEvents
       ? correctedEvents

--- a/apps/web/src/components/SimpleHome.tsx
+++ b/apps/web/src/components/SimpleHome.tsx
@@ -273,9 +273,16 @@ export function SimpleHome() {
     setPendingRestore(null);
   }
 
-  function handleDiscardPending() {
+  async function handleDiscardPending() {
+    // clear の永続化を待ってから prompt を閉じる。prompt が消える = 破棄完了、
+    // というシグナルにすることで「破棄 → 即リロードで pending が残る」race を断つ
+    // (#211: IndexedDB clear が未コミットのままリロードすると復元プロンプトが再出現)。
+    try {
+      await clearPendingRecordings();
+    } catch {
+      // IndexedDB が使えない環境でも UI は閉じる
+    }
     setPendingRestore(null);
-    clearPendingRecordings().catch(() => {});
   }
 
   const runTranscription = useCallback(

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,6 +1,7 @@
 import {
   CorrectionsPayload,
   InstrumentTuning,
+  RecognitionRunsResponse,
   ReviewQueueEntry,
   ReviewStatusPayload,
   ReviewStatusValue,
@@ -236,6 +237,61 @@ export async function fetchTranscription(transactionId: string): Promise<Transcr
   });
   if (!response.ok) {
     throw new Error("Failed to load transcription.");
+  }
+  return response.json();
+}
+
+// #204 Phase 2: recognition run history (see runs storage in apps/api/app/storage.py).
+
+export async function fetchTranscriptionRuns(
+  transactionId: string,
+): Promise<RecognitionRunsResponse> {
+  const response = await fetch(`${API_BASE_URL}/api/transcriptions/${transactionId}/runs`, {
+    cache: "no-store",
+  });
+  if (!response.ok) {
+    throw new Error("Failed to load recognition runs.");
+  }
+  return response.json();
+}
+
+export async function fetchTranscriptionRun(
+  transactionId: string,
+  runId: string,
+): Promise<TranscriptionResult> {
+  const response = await fetch(
+    `${API_BASE_URL}/api/transcriptions/${transactionId}/runs/${encodeURIComponent(runId)}`,
+    { cache: "no-store" },
+  );
+  if (!response.ok) {
+    throw new Error("Failed to load recognition run.");
+  }
+  return response.json();
+}
+
+export type CreateRunResult = {
+  runId: string;
+  transactionId: string;
+  meta: {
+    runId: string;
+    commitSha: string | null;
+    recognizerFingerprint: string | null;
+    dspFingerprint: string | null;
+    ranAt: string;
+  };
+  result: TranscriptionResult;
+};
+
+/** 保存済み録音+チューニングで現行の認識器を再実行し、新しい run を追記する
+ * (#204 Phase 1 のエンドポイント)。force=true の再アップロードと違い、新しい
+ * transactionId は発行されない (重複 tx を作らないのが正規解)。 */
+export async function createTranscriptionRun(transactionId: string): Promise<CreateRunResult> {
+  const response = await fetch(`${API_BASE_URL}/api/transcriptions/${transactionId}/runs`, {
+    method: "POST",
+  });
+  if (!response.ok) {
+    const detail = await parseError(response);
+    throw new Error(detail);
   }
   return response.json();
 }

--- a/apps/web/src/lib/reviewCorrections.ts
+++ b/apps/web/src/lib/reviewCorrections.ts
@@ -427,9 +427,18 @@ export function hasActiveEventAt(
   );
 }
 
-export function toCorrectionsPayload(state: ReviewState): CorrectionsPayload {
+/**
+ * baseRunId (#204 Phase 3): どの認識結果 (run) に対する差分として保存するかの
+ * 記録。省略時 (undefined) は "unknown base" として baseRunId を出力しない
+ * (呼び出し側が読み込み時の run を把握できなかった場合のフォールバック)。
+ */
+export function toCorrectionsPayload(
+  state: ReviewState,
+  baseRunId?: string | null,
+): CorrectionsPayload {
   return {
     version: 1,
+    ...(baseRunId !== undefined ? { baseRunId } : {}),
     events: activeEvents(state).map((event) => ({
       timeSec: event.timeSec,
       notes: event.notes.map(noteName),

--- a/apps/web/src/lib/reviewCorrections.ts
+++ b/apps/web/src/lib/reviewCorrections.ts
@@ -428,17 +428,14 @@ export function hasActiveEventAt(
 }
 
 /**
- * baseRunId (#204 Phase 3): どの認識結果 (run) に対する差分として保存するかの
- * 記録。省略時 (undefined) は "unknown base" として baseRunId を出力しない
- * (呼び出し側が読み込み時の run を把握できなかった場合のフォールバック)。
+ * baseRunId (#204 Phase 3) は「保存時にどの run に対する差分か」を記録するもので、
+ * dirty 判定用の payload には含めたくない (内容が同じなら run だけで dirty 扱いに
+ * しないため)。そのため付与は ReviewEditor の保存時スプレッド 1 箇所に集約し、この
+ * 関数では扱わない (#209 review: 未使用の任意引数による二重機構を排除)。
  */
-export function toCorrectionsPayload(
-  state: ReviewState,
-  baseRunId?: string | null,
-): CorrectionsPayload {
+export function toCorrectionsPayload(state: ReviewState): CorrectionsPayload {
   return {
     version: 1,
-    ...(baseRunId !== undefined ? { baseRunId } : {}),
     events: activeEvents(state).map((event) => ({
       timeSec: event.timeSec,
       notes: event.notes.map(noteName),

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -67,6 +67,10 @@ export type CorrectionEventPayload = {
 export type CorrectionsPayload = {
   version: 1;
   updatedAt?: string | null;
+  // #204 Phase 3: which recognition run these corrections were made against
+  // ("legacy", or a runId from GET .../runs). Absent/null for corrections
+  // saved before this field existed.
+  baseRunId?: string | null;
   events: CorrectionEventPayload[];
 };
 
@@ -103,6 +107,28 @@ export type ReviewQueueEntry = {
   // queue の優先度ソートにのみ使う。旧 payload では null/undefined。
   qualityDifficulty?: number | null;
   qualityFlag?: string | null;
+  // #204 Phase 2: 表示中の response が保存された時点の recognizer fingerprint と、
+  // それが現行 recognizer と異なるか (再認識対象の目印)。fingerprint 不明な
+  // 旧録音では isStale は null (安全側: stale と決めつけない)。
+  recognizerFingerprint?: string | null;
+  isStale?: boolean | null;
+};
+
+// #204 Phase 1/2: 1 件の認識実行 (recognition run)。isLegacy=true はアップロード時
+// スナップショット (response.json) を表す合成エントリで、ranAt は null。
+export type RecognitionRun = {
+  runId: string;
+  commitSha: string | null;
+  recognizerFingerprint: string | null;
+  dspFingerprint: string | null;
+  ranAt: string | null;
+  eventCount: number;
+  isLegacy: boolean;
+};
+
+export type RecognitionRunsResponse = {
+  runs: RecognitionRun[];
+  latestRunId: string | null;
 };
 
 export type NotationViews = {

--- a/scripts/audio-analysis/README.md
+++ b/scripts/audio-analysis/README.md
@@ -267,6 +267,22 @@ uv run python scripts/audio-analysis/metamorphic_alarm.py --tx <tx-id> --json --
 uv run python scripts/audio-analysis/metamorphic_alarm.py --strict
 ```
 
+### bulk_recognition_runs.py
+#204 Phase 3 の「corpus 一括再認識ツール」。`POST /api/transcriptions/{id}/runs`
+(#204 Phase 1、force=true の重複 tx 問題の正規解) を `KALIMBA_DATA_DIR` 配下の
+transaction すべてに対して in-process (TestClient、サーバー不要) で呼び出し、
+保存済み recognizerFingerprint が現行と異なる (または不明な) 録音だけを既定で
+対象にする。前後比較は metamorphic_alarm.py と同じ手法 (`note_f1_benchmark` の
+`match_pairs` を「再認識前の出力 = 疑似正解」として再利用) で added/dropped を
+報告する。report-only ではなく実際に run を追記するツールなので、テスト/デモ
+実行は必ず `--data-dir` で一時ディレクトリの合成データを指す (AGENTS.md)。
+
+```bash
+uv run python scripts/audio-analysis/bulk_recognition_runs.py --dry-run
+uv run python scripts/audio-analysis/bulk_recognition_runs.py --data-dir /tmp/scratch-data
+uv run python scripts/audio-analysis/bulk_recognition_runs.py --all --json
+```
+
 ## 判定基準
 
 ### ノイズ vs 楽音の判定

--- a/scripts/audio-analysis/README.md
+++ b/scripts/audio-analysis/README.md
@@ -275,7 +275,9 @@ transaction すべてに対して in-process (TestClient、サーバー不要) �
 対象にする。前後比較は metamorphic_alarm.py と同じ手法 (`note_f1_benchmark` の
 `match_pairs` を「再認識前の出力 = 疑似正解」として再利用) で added/dropped を
 報告する。report-only ではなく実際に run を追記するツールなので、テスト/デモ
-実行は必ず `--data-dir` で一時ディレクトリの合成データを指す (AGENTS.md)。
+実行は必ず `--data-dir` で一時ディレクトリの合成データを指す (共有 `data/` や
+committed corpus を tooling で変更しない — AGENTS.md の Fixture Policy /
+Corpus Management)。
 
 ```bash
 uv run python scripts/audio-analysis/bulk_recognition_runs.py --dry-run

--- a/scripts/audio-analysis/bulk_recognition_runs.py
+++ b/scripts/audio-analysis/bulk_recognition_runs.py
@@ -89,7 +89,10 @@ def candidate_transaction_ids(tx_root: Path) -> list[str]:
 def process_transaction(client, storage, tx_id: str, *, dry_run: bool) -> dict:
     before_response = storage.load_latest_response(tx_id) or {}
     before_notes = nfb.collect_one_best(before_response) if before_response.get("events") else []
-    before_run_id = storage.latest_run_id(tx_id) or "legacy"
+    # #209 review: before_response is display-resolved (newest *readable* run), so
+    # name the same run — not latest_run_id, which points at a corrupt newest dir
+    # whose notes were not the ones diffed.
+    before_run_id = storage.latest_displayed_run_id(tx_id) or "legacy"
     saved_fingerprint = storage.resolved_recognizer_fingerprint(tx_id)
 
     if dry_run:
@@ -200,7 +203,7 @@ def main() -> int:
 
     from fastapi.testclient import TestClient
     from apps.api.app import storage
-    from apps.api.app.fingerprints import recognizer_fingerprint
+    from apps.api.app.fingerprints import kalimba_dsp_fingerprint, recognizer_fingerprint
     from apps.api.app.main import app
 
     tx_root = storage.get_transactions_dir()
@@ -210,16 +213,22 @@ def main() -> int:
         return 1
 
     current_fp = recognizer_fingerprint()
+    current_dsp = kalimba_dsp_fingerprint()
     targets: list[str] = []
     skipped_fresh: list[str] = []
     for tx_id in candidates:
-        # Reuse the review-queue's composite (recognizer + kalimba_dsp) staleness
-        # signal so a DSP-only change is not silently treated as fresh (#209
-        # review). Only a verified-current recording (is_response_stale is False)
-        # is skipped; unknown (None) counts as a target — see module docstring:
-        # unlike the badge, this tool need not be conservative about guessing,
-        # since re-running is safe and append-only.
-        is_fresh = storage.is_response_stale(tx_id) is False
+        # Backfill policy (distinct from the review-queue badge's conservative None,
+        # #209 review): skip only recordings VERIFIED current on *both* output
+        # components — recognizer (Python) AND kalimba_dsp (Rust). Anything with a
+        # differing OR unknown fingerprint (incl. runs predating dsp fingerprints)
+        # is targeted, per this tool's "unknown provenance → re-run" stance (safe &
+        # append-only). A DSP-only change is therefore not silently treated as fresh.
+        saved_fp, saved_dsp = storage.resolved_output_fingerprints(tx_id)
+        is_fresh = (
+            saved_fp == current_fp
+            and saved_dsp is not None
+            and saved_dsp == current_dsp
+        )
         if args.all or not is_fresh:
             targets.append(tx_id)
         else:

--- a/scripts/audio-analysis/bulk_recognition_runs.py
+++ b/scripts/audio-analysis/bulk_recognition_runs.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Bulk re-recognition across local transactions (#204 Phase 3).
+
+Issue #204's core problem: force=true re-uploading a stored recording used to
+mint a brand-new transaction, so re-recognizing many recordings after a
+recognizer change produced duplicate transactions instead of a tracked
+history. Phase 1 fixed the single-recording case with
+``POST /api/transcriptions/{id}/runs`` (append a run, no new transaction id).
+This script is the "do that for every recording that needs it" tool the
+issue's Phase 3 section calls for ("corpus 一括再認識ツール"), calling the
+same endpoint in-process (via ``fastapi.testclient.TestClient``, no server
+needed) for every transaction under a data directory whose saved recognizer
+fingerprint no longer matches the recognizer currently loaded.
+
+Before/after comparison: reuses ``note_f1_benchmark.collect_one_best`` /
+``match_pairs`` exactly like ``metamorphic_alarm.py`` does, treating the
+previously-resolved response as a pseudo ground truth and the freshly
+created run's output as "predicted" — so "false negatives" are notes the new
+run dropped and "false positives" are notes the new run added relative to
+what was there before. This is the same shape of before/after evaluation the
+per-tine research line's dual-run comparisons want (AGENTS.md, #204 issue
+body), reused rather than reimplemented.
+
+Staleness default vs. the review-queue badge: the review queue
+(GET /api/review-queue, ``app.storage.resolved_recognizer_fingerprint``)
+treats an unknown saved fingerprint (pre-#204 recordings) as "isStale: None"
+— it deliberately does not guess, because a wrong guess would mislead a
+human triaging the queue. This tool's *default* target set is broader on
+purpose: "verified current" (saved fingerprint == running recognizer) is
+excluded, and everything else (fingerprint differs OR fingerprint unknown)
+is a candidate, because re-running is cheap, append-only, and safe, and
+backfilling provenance for old recordings is one of the useful side effects
+of running this tool at all. Pass ``--all`` to bypass the filter entirely
+(re-run every matching transaction regardless of freshness) or ``--tx`` to
+restrict to specific ids.
+
+Data dir: like the API server itself, this reads ``KALIMBA_DATA_DIR`` (via
+``app.storage``'s own env lookup, re-evaluated on every call) or defaults to
+`./data`. Pass ``--data-dir`` to point at a scratch/synthetic directory
+instead of touching real local data — this is REQUIRED for any test/demo run
+of this script per AGENTS.md ("一括再認識の実行テストは必ず一時ディレクトリ
+の合成データで行う"); never point it at the shared repo `data/` directory or
+at `apps/api/tests/fixtures/free-performance-corpus/` from an automated
+run.
+
+REPORT + PERSIST (not report-only): unlike metamorphic_alarm.py, this tool
+actually appends recognition runs (unless --dry-run is passed). It has no
+CI/pytest wiring and is not a regression gate; it is an operator tool for
+"my recognizer changed, bring my locally-recorded corpus up to date."
+
+Usage:
+  uv run python scripts/audio-analysis/bulk_recognition_runs.py --dry-run
+  uv run python scripts/audio-analysis/bulk_recognition_runs.py --data-dir /tmp/scratch-data
+  uv run python scripts/audio-analysis/bulk_recognition_runs.py --tx <tx-id> --tx <tx-id>
+  uv run python scripts/audio-analysis/bulk_recognition_runs.py --all --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent.parent
+sys.path.insert(0, str(SCRIPT_DIR))
+sys.path.insert(0, str(REPO_ROOT))
+
+import note_f1_benchmark as nfb  # noqa: E402
+
+DEFAULT_JSON_OUT = SCRIPT_DIR / "reports" / "bulk_recognition_runs.json"
+
+
+def candidate_transaction_ids(tx_root: Path) -> list[str]:
+    if not tx_root.is_dir():
+        return []
+    return sorted(
+        d.name
+        for d in tx_root.iterdir()
+        if d.is_dir() and (d / "audio.wav").is_file() and (d / "request.json").is_file()
+    )
+
+
+def process_transaction(client, storage, tx_id: str, *, dry_run: bool) -> dict:
+    before_response = storage.load_latest_response(tx_id) or {}
+    before_notes = nfb.collect_one_best(before_response) if before_response.get("events") else []
+    before_run_id = storage.latest_run_id(tx_id) or "legacy"
+    saved_fingerprint = storage.resolved_recognizer_fingerprint(tx_id)
+
+    if dry_run:
+        return {
+            "txId": tx_id,
+            "beforeRunId": before_run_id,
+            "savedFingerprint": saved_fingerprint,
+            "beforeEventCount": len(before_notes),
+            "dryRun": True,
+        }
+
+    response = client.post(f"/api/transcriptions/{tx_id}/runs")
+    if response.status_code != 200:
+        return {
+            "txId": tx_id,
+            "beforeRunId": before_run_id,
+            "savedFingerprint": saved_fingerprint,
+            "error": f"HTTP {response.status_code}: {response.text[:300]}",
+        }
+    body = response.json()
+    after_notes = nfb.collect_one_best(body["result"])
+    pseudo_truth = [
+        {"time": n["time"], "note": n["note"], "tol": nfb.DEFAULT_TOLERANCE_SEC} for n in before_notes
+    ]
+    # Reuse note_f1_benchmark's matcher for output-to-output comparison (same
+    # technique as metamorphic_alarm.py): "before" stands in for ground truth,
+    # so falseNegatives = notes the new run dropped, falsePositives = notes it
+    # added, relative to what was there before this run.
+    match = nfb.match_pairs(pseudo_truth, after_notes)
+    dropped = match["falseNegatives"]
+    added = match["falsePositives"]
+    return {
+        "txId": tx_id,
+        "beforeRunId": before_run_id,
+        "afterRunId": body["runId"],
+        "savedFingerprintBefore": saved_fingerprint,
+        "recognizerFingerprintAfter": body["meta"]["recognizerFingerprint"],
+        "beforeEventCount": len(before_notes),
+        "afterEventCount": len(after_notes),
+        "unchangedCount": match["tp"],
+        "addedCount": len(added),
+        "droppedCount": len(dropped),
+        "added": [{"time": round(a["time"], 3), "note": a["note"]} for a in added],
+        "dropped": [{"time": round(d_["time"], 3), "note": d_["note"]} for d_ in dropped],
+    }
+
+
+def print_table(output: dict) -> None:
+    summary = output["summary"]
+    print(
+        f"recognizer {summary['recognizerFingerprint']}  dataDir={summary['dataDir']}"
+        f"  candidates={summary['candidateCount']}  targeted={summary['targetedCount']}"
+        f"  skipped(fresh)={summary['skippedFreshCount']}"
+        f"{'  DRY RUN' if summary['dryRun'] else ''}"
+    )
+    print()
+    print(f"{'txId':38} {'before':>7} {'after':>7} {'same':>5} {'add':>4} {'drop':>5}  note")
+    for r in output["results"]:
+        if r.get("dryRun"):
+            print(f"{r['txId'][:36]:38} {r['beforeEventCount']:>7}  (dry-run, no new run created)")
+            continue
+        if "error" in r:
+            print(f"{r['txId'][:36]:38} ERROR: {r['error']}")
+            continue
+        note = "" if (r["addedCount"] or r["droppedCount"]) else "unchanged"
+        print(
+            f"{r['txId'][:36]:38} {r['beforeEventCount']:>7} {r['afterEventCount']:>7}"
+            f" {r['unchangedCount']:>5} {r['addedCount']:>4} {r['droppedCount']:>5}  {note}"
+        )
+    changed = [r for r in output["results"] if not r.get("dryRun") and "error" not in r and (r["addedCount"] or r["droppedCount"])]
+    errors = [r for r in output["results"] if "error" in r]
+    print()
+    if changed:
+        print(f"{len(changed)} of {len(output['results'])} re-recognitions changed the note-level output:")
+        for r in changed:
+            print(f"  {r['txId']}: +{r['addedCount']} added / -{r['droppedCount']} dropped")
+    if errors:
+        print(f"{len(errors)} transaction(s) errored: {[e['txId'] for e in errors]}")
+    if not changed and not errors:
+        print("No changes in note-level output for any re-recognized transaction.")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--data-dir", type=Path, default=None,
+        help="KALIMBA_DATA_DIR override (defaults to the env var, or ./data). "
+             "REQUIRED to be a scratch/synthetic dir for any test/demo run.",
+    )
+    parser.add_argument("--tx", action="append", dest="tx_ids", help="restrict to these tx ids (repeatable)")
+    parser.add_argument(
+        "--all", action="store_true",
+        help="re-recognize every candidate regardless of saved fingerprint (default: skip "
+             "recordings whose saved fingerprint already matches the current recognizer)",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="report which transactions would be targeted, without calling the recognizer "
+             "or persisting any run",
+    )
+    parser.add_argument("--json", action="store_true", help="print JSON to stdout instead of a table")
+    parser.add_argument("--json-out", type=Path, default=DEFAULT_JSON_OUT, help="write full JSON results here")
+    parser.add_argument("--no-write", action="store_true", help="do not write the JSON report file, stdout only")
+    args = parser.parse_args()
+
+    if args.data_dir is not None:
+        os.environ["KALIMBA_DATA_DIR"] = str(args.data_dir)
+
+    from fastapi.testclient import TestClient
+    from apps.api.app import storage
+    from apps.api.app.fingerprints import recognizer_fingerprint
+    from apps.api.app.main import app
+
+    tx_root = storage.get_transactions_dir()
+    candidates = args.tx_ids or candidate_transaction_ids(tx_root)
+    if not candidates:
+        print(f"No transactions found under {tx_root}.", file=sys.stderr)
+        return 1
+
+    current_fp = recognizer_fingerprint()
+    targets: list[str] = []
+    skipped_fresh: list[str] = []
+    for tx_id in candidates:
+        saved_fp = storage.resolved_recognizer_fingerprint(tx_id)
+        # Unknown fingerprint counts as a target (see module docstring): unlike
+        # the review-queue badge, this tool does not need to be conservative
+        # about guessing, since re-running is safe and append-only.
+        is_fresh = saved_fp is not None and saved_fp == current_fp
+        if args.all or not is_fresh:
+            targets.append(tx_id)
+        else:
+            skipped_fresh.append(tx_id)
+
+    client = TestClient(app)
+    results = [process_transaction(client, storage, tx_id, dry_run=args.dry_run) for tx_id in targets]
+
+    summary = {
+        "generatedAt": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S+00:00"),
+        "recognizerFingerprint": current_fp,
+        "dataDir": str(tx_root.parent),
+        "candidateCount": len(candidates),
+        "targetedCount": len(targets),
+        "skippedFreshCount": len(skipped_fresh),
+        "dryRun": args.dry_run,
+        "all": args.all,
+    }
+    output = {"summary": summary, "results": results}
+
+    if not args.no_write:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(json.dumps(output, indent=2) + "\n", encoding="utf-8")
+
+    if args.json:
+        print(json.dumps(output, indent=2))
+    else:
+        print_table(output)
+
+    if any("error" in r for r in results):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audio-analysis/bulk_recognition_runs.py
+++ b/scripts/audio-analysis/bulk_recognition_runs.py
@@ -38,10 +38,12 @@ Data dir: like the API server itself, this reads ``KALIMBA_DATA_DIR`` (via
 ``app.storage``'s own env lookup, re-evaluated on every call) or defaults to
 `./data`. Pass ``--data-dir`` to point at a scratch/synthetic directory
 instead of touching real local data — this is REQUIRED for any test/demo run
-of this script per AGENTS.md ("一括再認識の実行テストは必ず一時ディレクトリ
-の合成データで行う"); never point it at the shared repo `data/` directory or
-at `apps/api/tests/fixtures/free-performance-corpus/` from an automated
-run.
+of this script: never point it at the shared repo `data/` directory or at
+`apps/api/tests/fixtures/free-performance-corpus/` from an automated run.
+This follows AGENTS.md's Fixture Policy / Corpus Management sections (committed
+corpus and shared transaction data are not to be mutated by tooling), even
+though the specific wording here is this script's own, not a quote from
+AGENTS.md.
 
 REPORT + PERSIST (not report-only): unlike metamorphic_alarm.py, this tool
 actually appends recognition runs (unless --dry-run is passed). It has no
@@ -211,11 +213,13 @@ def main() -> int:
     targets: list[str] = []
     skipped_fresh: list[str] = []
     for tx_id in candidates:
-        saved_fp = storage.resolved_recognizer_fingerprint(tx_id)
-        # Unknown fingerprint counts as a target (see module docstring): unlike
-        # the review-queue badge, this tool does not need to be conservative
-        # about guessing, since re-running is safe and append-only.
-        is_fresh = saved_fp is not None and saved_fp == current_fp
+        # Reuse the review-queue's composite (recognizer + kalimba_dsp) staleness
+        # signal so a DSP-only change is not silently treated as fresh (#209
+        # review). Only a verified-current recording (is_response_stale is False)
+        # is skipped; unknown (None) counts as a target — see module docstring:
+        # unlike the badge, this tool need not be conservative about guessing,
+        # since re-running is safe and append-only.
+        is_fresh = storage.is_response_stale(tx_id) is False
         if args.all or not is_fresh:
             targets.append(tx_id)
         else:


### PR DESCRIPTION
## Summary

Implements #204 Phase 2 (run-switcher UI, queue stale badge) and Phase 3 (corrections baseRunId, corpus bulk re-recognition tool) on top of Phase 1 (#207, merged as b627c47).

### Phase 2

- `GET /api/transcriptions/{id}/runs/{runId}` — full payload for a single historical run (including the synthetic `legacy` id), complementing Phase 1's summary-only `GET .../runs`.
- Recording listings (`_summarize_transaction`, backing both `/api/transcriptions/recent` and `/api/review-queue`) now carry `recognizerFingerprint` (fingerprint the shown response was produced with) and `isStale` (whether it differs from the recognizer running now). `isStale` is `null` rather than a guess when the saved fingerprint is unknown (pre-#204 recordings).
- `ScoreViewer` (`/score/[id]`) fetches the run history and adds a `RunHistoryPanel`: a dropdown over all runs (legacy + each re-recognition) plus a "現在の認識器で再認識" button that calls `POST .../runs` and switches the view to the new run. The #202 corrected/recognized toggle only shows while viewing the run present at page load, since `correctedEvents` is matched against that run's events and isn't aligned to arbitrary other runs (historical or freshly re-run).
- `ReviewQueue` shows a "更新あり" badge when `isStale` is true.

### Phase 3

- `CorrectionsPayload` (API model + web type) gains an optional `baseRunId` (`"legacy"` or a runId) recording which recognition run a correction's timeline is a diff against. `ReviewEditor` captures the run it loaded against and includes it on every save. Provenance only — does not change how corrections are matched to recognizer output (`reviewCorrections.ts`'s existing +/-50ms rematch already tolerates drift).
- `scripts/audio-analysis/bulk_recognition_runs.py` — the "corpus 一括再認識ツール": calls `POST .../runs` in-process (`TestClient`, no server needed) for every transaction under `KALIMBA_DATA_DIR` whose saved fingerprint differs from (or is unknown relative to) the current recognizer, and reports before/after note-level diffs by reusing `note_f1_benchmark.match_pairs` the same way `metamorphic_alarm.py` does. `--all` bypasses the staleness filter, `--tx` restricts to specific ids, `--dry-run` reports without persisting.

## Test plan

- [x] `TMPDIR=/tmp uv run pytest apps/api/tests -q` — 621 passed (0 failed), including new tests for the per-run endpoint, queue staleness fields, and `baseRunId` round-trip.
- [x] `tsc --noEmit` (against the prod checkout's node_modules, symlinked in per the task's own instructions) — clean.
- [x] `bulk_recognition_runs.py` exercised end-to-end against a scratch `KALIMBA_DATA_DIR` with two synthetic transactions (one with its fingerprint overwritten to simulate staleness): default run targeted only the stale one and left the fresh one untouched; `--all` targeted both; `--tx` narrowed to one id; `--dry-run` persisted nothing. Shared repo `data/` was never touched.
- [x] Every new/changed API endpoint (`GET/POST .../runs`, `GET .../runs/{runId}`, `GET /api/review-queue`) exercised against a real running dev server (port 8001, scratch data dir) via curl, not just `TestClient`.
- [~] Live browser UI verification (Playwright, dev server on port 8001 + Next dev on 3002 against the same scratch data): blocked by an environment issue unrelated to this diff — this worktree's client bundle never hydrates when built against the prod checkout's *symlinked* node_modules (confirmed by the same failure on the untouched review-queue page and the home page's tuning dropdown, both pre-existing code). Caught a real bug instead via careful re-reading of the effect logic (see commit 234f919): a naive re-run effect would have clobbered the just-created run's result back to the stale page-load snapshot; fixed by tracking a separate "latest known result" state instead of relying on the fixed initial prop.

## Implemented vs. deferred

- Implemented: everything listed above under Phase 2/3.
- Deferred / out of scope for this PR:
  - The top-level "recent" list (home page) also now receives `recognizerFingerprint`/`isStale` from the same storage helper, but no UI badge was added there (issue text specifically calls out the queue).
  - `ReviewEditor` does not get its own run-switcher; it always edits against the run `fetchTranscription` resolves to (captured as `baseRunId`). Editing corrections against an arbitrary non-latest historical run was not implemented.

## Open questions / design points not decided unilaterally

1. **Staleness definition**: `isStale` (queue badge) and the bulk tool's default target filter both compare only `recognizerFingerprint`, not `dspFingerprint`. A `kalimba_dsp`-only rebuild (Rust extension change, no Python source change) would not be flagged as stale under this definition. Left as-is since the issue text names "recognizerFingerprint" specifically, but flagging in case DSP-only staleness should also count.
2. **Bulk tool's corpus scope**: `bulk_recognition_runs.py` targets `KALIMBA_DATA_DIR` (local `data/transactions`), not the repo-managed `apps/api/tests/fixtures/free-performance-corpus/` fixtures directly (that path isn't governed by `KALIMBA_DATA_DIR`). Writing runs into the committed corpus fixtures from an automated tool felt like the wrong default (it would add `runs/` subdirectories under version control on every recognizer change), so I left it pointed at the operator's own local data by default. If corpus-fixture-specific bulk re-recognition + before/after tracking is wanted, that would need its own explicit design decision (e.g. only report, never write into the committed fixture dirs).
3. **`baseRunId` consumption**: it's recorded but nothing currently reads it back (no GT-promotion or staleness-aware corrections warning uses it yet). The issue text frames it as provenance for future tooling, so I didn't invent a consumer.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

https://claude.ai/code/session_015dgF3V9WiMtkuJYufXDMT3
